### PR TITLE
EOS-8643: Require same verson of libsspl-sec when installing sspl

### DIFF
--- a/libsspl_sec/libsspl_sec.spec
+++ b/libsspl_sec/libsspl_sec.spec
@@ -9,7 +9,7 @@ Group:      Libraries/System
 License:    Seagate Proprietary
 URL:        http://gerrit.mero.colo.seagate.com:8080/#/admin/projects/sspl
 Source0:    %{product_family}-sspl-%{version}.tgz
-Requires:   %{product_family}-sspl
+Requires:   %{product_family}-sspl = %{version}-%{release}
 BuildRoot:  %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 Vendor:     Seagate Technology LLC
 #BuildArch:  x86_64

--- a/low-level/cli/sspl_cli.spec
+++ b/low-level/cli/sspl_cli.spec
@@ -13,7 +13,7 @@ Group:		System Management
 License:	Seagate Proprietary
 URL:		http://gerrit.mero.colo.seagate.com:8080/#/admin/projects/sspl
 Source0:	%{name}-%{version}.tgz
-Requires:   %{product_family}-sspl
+Requires:   %{product_family}-sspl = %{version}-%{release}
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 %description

--- a/low-level/sspl-ll.spec
+++ b/low-level/sspl-ll.spec
@@ -17,7 +17,10 @@ URL:        http://gerrit.mero.colo.seagate.com:8080/#/admin/projects/sspl
 Source0:    %{name}-%{version}.tgz
 BuildRoot:  %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildRequires: python36 rpm-build sudo
-Requires:   rabbitmq-server udisks2 hdparm python36 ipmitool %{product_family}-libsspl_sec %{product_family}-libsspl_sec-method_none
+Requires:   rabbitmq-server udisks2 hdparm python36 ipmitool
+Requires:   %{product_family}-libsspl_sec = %{version}-%{release}
+Requires:   %{product_family}-libsspl_sec-method_none = %{version}-%{release}
+
 #Requires:  python36-dbus python36-paramiko
 #Requires:  python36-psutil python36-gobject systemd-python36
 Requires:   perl(Config::Any) eos-py-utils

--- a/sspl_test/sspl-test.spec
+++ b/sspl_test/sspl-test.spec
@@ -13,7 +13,7 @@ Group:      System Management
 License:    Seagate Proprietary
 URL:        http://gerrit.mero.colo.seagate.com:8080/#/admin/projects/sspl
 Source0:    %{name}-%{version}.tgz
-Requires:   %{product_family}-sspl
+Requires:   %{product_family}-sspl = %{version}-%{release}
 BuildRoot:  %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 Requires:  python36-psutil
 


### PR DESCRIPTION
This fixes the [issue](https://jts.seagate.com/browse/EOS-8643) of handling of SSPL dependencies at the time of Install/Update

Before this,  at the time of SSPL rpm update, dependencies like libsspl_sec and libsspl_sec-method_none  was not getting update.

By adding version and release info with dependencies, they will also get updated to correct version(the SSPL version which is being installed)
