### PR TITLE
EOS-9838: EOS-RAS : For Realstor_enclosure sensor same event string is seen for fault_resolved and fault alert

### DIFF
--- a/low-level/sensors/impl/platforms/realstor/realstor_enclosure_sensor.py
+++ b/low-level/sensors/impl/platforms/realstor/realstor_enclosure_sensor.py
@@ -48,6 +48,7 @@ class RealStorEnclosureSensor(SensorThread, InternalMsgQ):
     RESOURCE_TYPE = "enclosure"
 
     ENCL_FAULT_RESOLVED_EVENTS = ["The network-port Ethernet link is down for controller A",\
+                            "The network-port Ethernet link is down for controller B",\
                             "The Management Controller IP address changed",\
                             "The Management Controller booted up.",\
                             "Both controllers have shut down; no restart",\
@@ -128,12 +129,11 @@ class RealStorEnclosureSensor(SensorThread, InternalMsgQ):
             elif mc_timeout_counter == 0 and self.previous_alert_type != self.rssencl.FRU_FAULT_RESOLVED \
                 and self.fault_alert == True:
 
-                self.alert_type = self.rssencl.FRU_FAULT_RESOLVED
-
                 # Check system status
                 self.system_status = self.check_system_status()
 
                 if self.system_status is not None:
+                    self.alert_type = self.rssencl.FRU_FAULT_RESOLVED
                     enclosure_status = self.system_status[0:5]
 
                     for status in enclosure_status:


### PR DESCRIPTION


Change-Id: Ic21171409b815d2b35f0695f3b38bc5c3201051b