### PR TITLE
EOS-8933: Fix automated sanity failure

### DIFF
--- a/low-level/files/opt/seagate/sspl/bin/sspl_config
+++ b/low-level/files/opt/seagate/sspl/bin/sspl_config
@@ -155,6 +155,7 @@ config_rabbitmq() {
     #out=$(rabbitmqctl cluster_status | grep running_nodes | cut -d '[' -f2 | cut -d ']' -f1 | sed 's/rabbit@//g' | sed 's/,/, /g')
     #pout=$(echo $out | sed  "s/'//g")
     #$CONSUL_PATH/consul kv put sspl/config/MESSAGINGCLUSTER/cluster_nodes $pout
+    return 0
 }
 
 cmd="config"


### PR DESCRIPTION
Automated sanity failed in sspl initialization for #56  because one step in sspl_config file returned exit code 1
Fixed `config_rabbitmq  ` steep. Now it returns 0 if `rmq_cluster_nodes `is not set.