### PR TITLE
SSPL side Changes for EOS-12296 HA: Replace contentious terms

### DIFF
--- a/low-level/files/opt/seagate/sspl/conf/setup.yaml
+++ b/low-level/files/opt/seagate/sspl/conf/setup.yaml
@@ -20,7 +20,7 @@ sspl:
          args:
             - reset hard -p LDR_R1
     ha:
-         script: /opt/seagate/cortx/ha/conf/script/build-ees-ha-sspl
+         script: /opt/seagate/cortx/ha/conf/script/build-ha-sspl
          args:
             - /opt/seagate/cortx/ha/conf/build-ees-ha-args.yaml
 


### PR DESCRIPTION
SSPL side change for the jira  EOS-12296 HA: Replace contentious terms

The file name change done in HA is reflected in SSPL by this PR
File name build-ees-ha-sspl is modified to build-ha-sspl