### PR TITLE
EOS-13062: Bug fix in sanity test

### DIFF
--- a/sspl_test/alerts/node/test_node_fan_actuator.py
+++ b/sspl_test/alerts/node/test_node_fan_actuator.py
@@ -33,9 +33,9 @@ test_resource = "*" # Use * if virtual machine
 result = run_cmd('ipmitool sdr type Fan')
 if result and not is_virtual():
         for resource in result:
-            if 'ok' in resource.decode():
+            if 'ok' in resource.decode().lower():
                 # this is the first ok resource, use it in case of real HW
-                test_resource = resource.decode().split(' ')[0]
+                test_resource = resource.decode().split('|')[0].strip()
                 break
 
 def init(args):

--- a/sspl_test/alerts/self_hw/test_self_hw_node_sel_event.py
+++ b/sspl_test/alerts/self_hw/test_self_hw_node_sel_event.py
@@ -82,13 +82,13 @@ def test_self_hw_node_sel_event(args):
     test_resource = None
     if result:
         for resource in result:
-            if 'ok' in resource.decode():
+            if 'ok' in resource.decode().lower():
                 # this is the first ok resource, use it
-                test_resource = resource.decode().split(' ')[0]
+                test_resource = resource.decode().split('|')[0].strip()
                 break
         # inject event into sel list and wait for alert
         print(f"Using test resource {test_resource}")
-        run_cmd(f'ipmitool event {test_resource} lcr')
+        run_cmd(f"ipmitool event '{test_resource}' lcr")
         # wait for fault alert
         start_time = time.time()
         asserted = False
@@ -100,7 +100,7 @@ def test_self_hw_node_sel_event(args):
             print("Did not get asserted event alert.")
             assert(False)
         # revert the event
-        run_cmd(f'ipmitool event {test_resource} lcr deassert')
+        run_cmd(f"ipmitool event '{test_resource}' lcr deassert")
         # wait for alert
         start_time = time.time()
         deasserted = False


### PR DESCRIPTION
SSPL sanity test checks for an "ok" resource to use in some test cases, and on Intel servers, these resources have blank space in their names. This was interfering with the string manipulation to get the resource name.