### PR TITLE
Change for EOS-12966 Beta RC14: IPMI Fan Failure Alerts Date / Time i…

### DIFF
--- a/low-level/sensors/impl/generic/node_hw.py
+++ b/low-level/sensors/impl/generic/node_hw.py
@@ -26,6 +26,7 @@ import json
 import re
 import socket
 import uuid
+import calendar
 
 from zope.interface import implementer
 
@@ -1312,7 +1313,7 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
     def _get_epoch_time_from_date_and_time(self, _date, _time):
         timestamp_format = '%m/%d/%Y %H:%M:%S'
         timestamp = time.strptime('{} {}'.format(_date,_time), timestamp_format)
-        return str(int(time.mktime(timestamp)))
+        return str(int(calendar.timegm(timestamp)))
 
     def suspend(self):
         """Suspends the module thread. It should be non-blocking"""


### PR DESCRIPTION
…s shown in UTC instead of System Time Zone(IST)

Modified the function _get_epoch_time_from_date_and_time to return epoch time in  UTC instead of local time

Testing done :
In function _get_epoch_time_from_date_and_time
Verified that the  _date, _time passed to this function is in UTC
Printed the time that is returned by the function by using  return str(int(time.mktime(timestamp)))
Verified that this is epoch using current time
Printed the time using calendar.timegm ; while using the same _date, _time parameters  passed to this function
and verified that the epoch in this case is in UTC 