### PR TITLE
EOS-10422: Fix realstor disk sensor

### DIFF
--- a/low-level/framework/platforms/realstor/realstor_enclosure.py
+++ b/low-level/framework/platforms/realstor/realstor_enclosure.py
@@ -394,6 +394,7 @@ class RealStorEnclosure(StorageEnclosure):
                 # list and find item in that.
                 if not self.FAULT_KEY in system.keys():
                     logger.debug("{0} Healthy, no faults seen".format(self.LDR_R1_ENCL))
+                    self.latest_faults = {}
                     return
 
                 # Extract system faults


### PR DESCRIPTION
This fixes realstor disk enable alerts issues like [EOS-10422](https://jts.seagate.com/browse/EOS-10422) and probably [EOS-7876](https://jts.seagate.com/browse/EOS-7876) also

This is occasional issue when realstor do not have any fault(in /show/system) and following steps are performed
- Disable a drive
- Enable a drive

If drive is enabled, /show/system will not return any fault. So latest fault will not be updated and state change will no be detected . After Disabling another driver, /show/system returns fault. So latest fault will be updated, state change will be detected and fault (for the other disabled drive) and fault_resolved(for enabled drive) will be generated.

This can be solved by updating latest fault to [] when there is not faults in /show/system