### PR TITLE
EOS-13204: Fix event_time value for node:os:disk alerts

### DIFF
--- a/low-level/sensors/impl/centos_7/systemd_watchdog.py
+++ b/low-level/sensors/impl/centos_7/systemd_watchdog.py
@@ -1133,7 +1133,7 @@ class SystemdWatchdog(SensorThread, InternalMsgQ):
     def _send_msg(self, alert_type, resource_id, specific_info):
         """Sends an internal msg to DiskMsgHandler"""
 
-        event_time = str(time.time())
+        event_time = str(int(time.time()))
         severity_reader = SeverityReader()
         msg =  {"sensor_response_type" : "node_disk",
                "response" : {


### PR DESCRIPTION
This fixes [EOS-13204](https://jts.seagate.com/browse/EOS-13204).
event_time was not aligned with other alert messages. Changed event_time to int