### PR TITLE
EOS-13299 : Skip few steps when doing SSPL initialization for node re…

### DIFF
--- a/low-level/files/opt/seagate/sspl/bin/constants.sh
+++ b/low-level/files/opt/seagate/sspl/bin/constants.sh
@@ -28,3 +28,5 @@ CONSUL_PORT="8500"
 ENVIRONMENT="PROD"
 CONSUL_PATH="/opt/seagate/$PRODUCT_FAMILY/hare/bin"
 CONSUL_FALLBACK_PATH="/opt/seagate/$PRODUCT_FAMILY/sspl/bin"
+# This file will be created when sspl is being configured for node replacement case
+REPLACEMENT_NODE_ENV_VAR_FILE="/etc/profile.d/set_replacement_env.sh"

--- a/low-level/files/opt/seagate/sspl/bin/sspl_config
+++ b/low-level/files/opt/seagate/sspl/bin/sspl_config
@@ -151,12 +151,18 @@ config_sspl() {
     # "/var/log/messages"
     systemctl restart rsyslog
 
+    # For node replacement scenario consul will not be running on the new node. But,
+    # there will be two instance of consul running on healthy node. When new node is configured
+    # consul will be brought back on it. We are using VIP to connect to consul. So, if consul
+    # is not running on new node, we dont need to error out.
     # If consul is not running, exit
-    CONSUL_PS=$(ps -aux | grep "consul" | grep -v "grep" || true)
-    if [ -z "$CONSUL_PS" ]; then
-        echo "Consul is not running, exiting..";
-        exit 1
-    fi
+    [ -f $REPLACEMENT_NODE_ENV_VAR_FILE ] || {
+        CONSUL_PS=$(ps -aux | grep "consul" | grep -v "grep" || true)
+        if [ -z "$CONSUL_PS" ]; then
+            echo "Consul is not running, exiting..";
+            exit 1
+        fi
+    }
 
 }
 
@@ -172,19 +178,27 @@ case $cmd in
         ;;
 esac
 
+# Skip this step if sspl is being configured for node replacement scenario as consul data is already
+# available on healthy node
 # Updating RabbitMQ cluster nodes.
-[ -n "$rmq_cluster_nodes" ] && $CONSUL_PATH/consul kv put sspl/config/RABBITMQCLUSTER/cluster_nodes $rmq_cluster_nodes
+[ -f $REPLACEMENT_NODE_ENV_VAR_FILE ] || {
+    [ -n "$rmq_cluster_nodes" ] && $CONSUL_PATH/consul kv put sspl/config/RABBITMQCLUSTER/cluster_nodes $rmq_cluster_nodes
+}
 # Getting node names using rabbitmqctl is depreciated (EOS-8860)
 #out=$(rabbitmqctl cluster_status | grep running_nodes | cut -d '[' -f2 | cut -d ']' -f1 | sed 's/rabbit@//g' | sed 's/,/, /g')
 #pout=$(echo $out | sed  "s/'//g")
 #$CONSUL_PATH/consul kv put sspl/config/RABBITMQCLUSTER/cluster_nodes $pout
 
+# Skip this step if sspl is being configured for node replacement scenario as consul data is already
+# available on healthy node
 # Updating build requested log level
-log_level=`cat $DIR_NAME/conf/build-requested-loglevel | sed 's/ *$//'`
-case $log_level in
-    "DEBUG" | "INFO" | "WARNING" | "ERROR" | "CRITICAL")
-        $CONSUL_PATH/consul kv put sspl/config/SYSTEM_INFORMATION/log_level $log_level;;
-    "");;
-    *)
-        echo "Unexpected log level is requested, '$log_level'";;
-esac
+[ -f $REPLACEMENT_NODE_ENV_VAR_FILE ] || {
+    log_level=`cat $DIR_NAME/conf/build-requested-loglevel | sed 's/ *$//'`
+    case $log_level in
+        "DEBUG" | "INFO" | "WARNING" | "ERROR" | "CRITICAL")
+            $CONSUL_PATH/consul kv put sspl/config/SYSTEM_INFORMATION/log_level $log_level;;
+        "");;
+        *)
+            echo "Unexpected log level is requested, '$log_level'";;
+    esac
+}

--- a/low-level/files/opt/seagate/sspl/bin/sspl_post_install
+++ b/low-level/files/opt/seagate/sspl/bin/sspl_post_install
@@ -58,8 +58,15 @@ while getopts ":p:e:c:" OPTION; do
     esac
 done
 
+# sspl_setup_consul script install consul in dev env and checks if consul process is running 
+# on prod. For node replacement scenario consul will not be running on the new node. But,
+# there will be two instance of consul running on healthy node. When new node is configured
+# consul will be brought back on it. We are using VIP to connect to consul. So, if consul
+# is not running on new node, we dont need to error out. So, need to skip this step for 
+# node replacement case
 # setup consul if not running already
-$script_dir/sspl_setup_consul -e $ENVIRONMENT
+[ -f $REPLACEMENT_NODE_ENV_VAR_FILE ] ||
+    $script_dir/sspl_setup_consul -e $ENVIRONMENT
 
 # Install packages which are not available in YUM repo, from PIP
 python3 -m pip install -r $SSPL_BASE_DIR/conf/requirements.txt
@@ -98,8 +105,15 @@ systemctl daemon-reload
 mkdir -p $PRODUCT_BASE_DIR/iem/iec_mapping
 cp -R $SSPL_BASE_DIR/resources/iem/iec_mapping/* $PRODUCT_BASE_DIR/iem/iec_mapping
 
+# Skip this step if sspl is being configured for node replacement scenario as sspl configurations are
+# already available in consul on the healthy node
 # Running script for fetching the config using salt and feeding values to consul
-$script_dir/sspl_fetch_config_from_salt.py $ENVIRONMENT $PRODUCT
+[ -f $REPLACEMENT_NODE_ENV_VAR_FILE ] ||
+    $script_dir/sspl_fetch_config_from_salt.py $ENVIRONMENT $PRODUCT
 
+# Skip this step if sspl is being configured for node replacement scenario as rabbitmq cluster is 
+# already configured on the healthy node
 # Configure rabbitmq
-[ "$RMQ_CLUSTER" == true ] && $script_dir/rabbitmq_setup
+[ -f $REPLACEMENT_NODE_ENV_VAR_FILE ] || {
+    [ "$RMQ_CLUSTER" == true ] && $script_dir/rabbitmq_setup
+}

--- a/low-level/files/opt/seagate/sspl/bin/sspl_setup
+++ b/low-level/files/opt/seagate/sspl/bin/sspl_setup
@@ -27,7 +27,6 @@ SCRIPT_DIR=$(dirname $0)
 . $SCRIPT_DIR/constants.sh
 
 SSPL_CONFIGURED="/var/$PRODUCT_FAMILY/sspl/sspl-configured"
-REPLACEMENT_NODE_ENV_VAR_FILE="/etc/profile.d/set_replacement_env.sh"
 
 usage() {
     cat << EOF
@@ -87,22 +86,7 @@ case $cmd in
 
     check )
         sudo python3 $SCRIPT_DIR/validate_consul_config.py
-
-        # Check if sspl-configured file exists at /var/cortx/sspl location.
-        # If not, then check if its a replaced node by checking existence of
-        # a file /etc/profile.d/set_replacement_env.sh. If its a replaced
-        # node, this file will be present. Otherwise, this file will not be
-        # present on the system.
-        [ -f $SSPL_CONFIGURED ] && exit $? || {
-
-            [[ -f $REPLACEMENT_NODE_ENV_VAR_FILE ]] && {
-
-                # Its a replaced node..Create that file and exit successfully
-                sudo touch $SSPL_CONFIGURED && exit $?
-            }
-        }
-        # sspl-configured file is not present and its not a replaced node either
-        # Log the error and exit.
+        [ -f $SSPL_CONFIGURED ] && exit $?
         logger -i -p local3.err "SSPL is not configured. Run provisioner scripts in $SSPL_BASE_DIR/bin."
         exit 1
         ;;


### PR DESCRIPTION
…placement scenario

After installing SSPL on replaced node, SSPL needed to be configured on that, but some steps are not required as required data/configuration is available on the heathy node.

Below steps will be skipped

start consul if not running
add config to consul
configure rabbitmq
update rabbitmq cluster nodes
update build requested log level

Signed-off-by: Thavanathan <thavanathan.thangaraj@seagate.com>