### PR TITLE
EOS-13332: M5: No 5U (enclosure)disk enable/disable, PSU, controller fault alerts seen on RMQ on Cross-connect(Inband) setup with 2830 build

### DIFF
--- a/low-level/framework/sspl_ll_d
+++ b/low-level/framework/sspl_ll_d
@@ -644,8 +644,9 @@ def signal_handler(signal_number, frame):
     if thread_controller_queue:
         send_thread_controller_request(state)
     else:
-        logger.info(f'thread_controller_queue is None, saving the sspl \
-                     role switch request state, State: {state}')
+        logger.warning(f'thread_controller_queue is not ready, saving the \
+                        sspl role switch request state, State: {state} to \
+                        process again later.')
 
         # This can be the edge case. SSPL is not yet fully initialized and it
         # received the signal to promote or may be demote. So, as the thread is


### PR DESCRIPTION
- Save the request to switch the SSPL role if thread is not yet ready to serve it
- Serve it whenever thread controller is ready to accept it