### PR TITLE
EOS-13693 - SSPL - Fixing sspl auth file getting removed by puppet-agent (main)

### DIFF
--- a/low-level/framework/sspl_reinit
+++ b/low-level/framework/sspl_reinit
@@ -57,8 +57,10 @@ chmod 440 /etc/sudoers.d/sspl
 # Set noop = true in puppet conf file to avoid the sspl auth file getting
 # removed by puppet-agent (Ref: LRL-495)
 PUPPET_CONF="/etc/puppetlabs/puppet/puppet.conf"
-PUPPET_NOOP="noop = true"
-grep -q "$PUPPET_NOOP" $PUPPET_CONF || echo "$PUPPET_NOOP" >> $PUPPET_CONF
+[ -f $PUPPET_CONF ] && {
+    PUPPET_NOOP="noop = true"
+    grep -q "$PUPPET_NOOP" $PUPPET_CONF || echo "$PUPPET_NOOP" >> $PUPPET_CONF
+}
 
 # Automatically install dependencies based on config file
 # There is no --checkdeps and --autoinstall implemented in sspl-ll-cli.


### PR DESCRIPTION
- Fix is to retain suoders.d/sspl by configuring puppet-agent

## Problem Statement
<pre>
  <code>
    Story Ref (if any): 
   EOS-13693 - SSPL - Fixing sspl auth file getting removed by puppet-agent
  </code>
</pre>
## Problem Description
<pre>
  <code>
After "EOS-12780 Release 2792 : Journalctl flooded with errors from sspl" fix, still observed auth error after long time sspl run.
  </code>
</pre>
## Solution
<pre>
  <code>
    Please add summary of the change,List any dependencies that are required for this change.
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - Yes
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
 - NA, log verification only.
  </code>
</pre>
