### PR TITLE
EOS-13436 : Improve healthview generation code

### DIFF
--- a/low-level/files/opt/seagate/sspl/bin/generate_resource_health_view/resource_health_view
+++ b/low-level/files/opt/seagate/sspl/bin/generate_resource_health_view/resource_health_view
@@ -1238,7 +1238,7 @@ if __name__ == "__main__":
     print(f"Server Type '{server_type}'")
 
     if storage_type == 'virtual' and server_type == 'virtual':
-        print("Resource Health View not supported for virtual server and virtual storage deployment")
+        print("Resource health view is not supported in virtual server and virtual storage deployment")
         print("Exiting ...")
         sys.exit(os.EX_USAGE)
 

--- a/low-level/files/opt/seagate/sspl/bin/generate_resource_health_view/resource_health_view
+++ b/low-level/files/opt/seagate/sspl/bin/generate_resource_health_view/resource_health_view
@@ -31,124 +31,71 @@ from dbus import SystemBus, Interface, Array
 from framework.utils.service_logging import logger
 import warnings
 warnings.filterwarnings(action='ignore',module='cryptography')
-
-# Add the top level directories
-op = os.path
-parentdir = op.dirname(op.dirname(op.dirname(op.dirname(op.dirname(op.dirname(op.dirname(op.abspath(__file__))))))))
-sys.path.insert(0, parentdir)
-from framework.base.sspl_constants import (component, CONSUL_HOST, CONSUL_PORT, node_key_id, PRODUCT_FAMILY,
-    storage_type, server_type
-)
-
-print(f"Storage Type : '{storage_type}'")
-print(f"Server Type '{server_type}'")
-
-if storage_type == 'virtual' and server_type == 'virtual':
-    print("Resource Health View does not support for virtual server and virtual storage deployment")
-    print("Exiting ...")
-    sys.exit(os.EX_USAGE)
-
-base_info = {'/SYSTEM_INFORMATION/site_id':'system_information/site_id',
-             '/SYSTEM_INFORMATION/rack_id':'system_information/rack_id',
-             '/SYSTEM_INFORMATION/node_id':f'system_information/{node_key_id}/node_id',
-             '/SYSTEM_INFORMATION/cluster_id':'system_information/cluster_id',
-             '/SYSTEM_INFORMATION/data_path':'system_information/data_path'}
-
-if storage_type == '5u84':
-    base_info.update({
-        '/STORAGE_ENCLOSURE/controller/primary_mc/ip':'storage_enclosure/controller/primary_mc/ip',
-        '/STORAGE_ENCLOSURE/controller/secondary_mc/ip':'storage_enclosure/controller/secondary_mc/ip',
-        '/STORAGE_ENCLOSURE/controller/primary_mc/port':'storage_enclosure/controller/primary_mc/port',
-        '/STORAGE_ENCLOSURE/controller/secondary_mc/port':'storage_enclosure/controller/secondary_mc/port',
-        '/STORAGE_ENCLOSURE/controller/user':'storage_enclosure/controller/user',
-        '/STORAGE_ENCLOSURE/controller/secret':'storage_enclosure/controller/password'
-    })
-host = os.getenv('CONSUL_HOST', CONSUL_HOST)
-port = os.getenv('CONSUL_PORT', CONSUL_PORT)
-try:
-    consul_conn = consul.Consul(host=host, port=port)
-    for key, value in base_info.items():
-        value = consul_conn.kv.get(value)[1]["Value"].decode()
-        if key.endswith('site_id'):
-            sys_site_id = value
-        elif key.endswith('rack_id'):
-            sys_rack_id = value
-        elif key.endswith('node_id'):
-            sys_node_id = value
-        elif key.endswith('cluster_id'):
-            sys_cluster_id = value
-        elif key.endswith('data_path'):
-            sys_data_path = value
-        consul_conn.kv.put(component+key, value)
-except Exception as serror:
-    print("Error in connecting consul: {}".format(serror))
-    print("Exiting ...")
-    sys.exit(os.EX_USAGE)
 from framework.utils.store_factory import store
-
-if storage_type == '5u84':
-    from framework.platforms.realstor.realstor_enclosure import singleton_realstorencl
 from framework.utils.ipmi_client import IpmiFactory
 from framework.utils.sysfs_interface import SysFS
 from framework.utils.tool_factory import ToolFactory
+from framework.base.sspl_constants import (component, CONSUL_HOST, CONSUL_PORT, node_key_id, PRODUCT_FAMILY,
+    storage_type, server_type, NODE_ID, SITE_ID, RACK_ID, DATA_PATH
+)
 
 class SSPLHealthView(object):
     """docstring for SSPLHealthView"""
 
-    persistent_data_location = sys_data_path
-    storage_encl_dir = persistent_data_location+'encl/frus/'
-
-    encl_disks_filename = storage_encl_dir+'disks/'
-    encl_psus_filename = storage_encl_dir+'psus/psudata.json'
-    encl_controllers_filename = storage_encl_dir+'controllers/controllerdata.json'
-    encl_fans_filename = storage_encl_dir+'fanmodules/fanmodule_data.json'
-    encl_sideplane_exp_filename = storage_encl_dir+'sideplane_expanders/sideplane_expanders_data.json'
-    encl_logical_volumes_filename = storage_encl_dir+'logical_volumes/logicalvolumedata.json'
-
-    jbod_disks_filename = persistent_data_location+'server/systemd_watchdog/disks/disks.json'
-
-    encl_disk_resource_type = "enclosure:fru:disk"
-    encl_controller_resource_type = "enclosure:fru:controller"
-    encl_fan_resource_type = "enclosure:fru:fan"
-    encl_psu_resource_type = "enclosure:fru:psu"
-    encl_sideplane_resource_type = "enclosure:fru:sideplane"
-    encl_logical_volume_resource_type = f"enclosure:{PRODUCT_FAMILY}:logical_volume"
-    encl_sas_resource_type = "enclosure:interface:sas"
-
-    undesired_vals = ["N/A", ""]
-
-    SITE_ID = sys_site_id
-    RACK_ID = sys_rack_id
-    HOST_NAME = socket.getfqdn()
-    NODE_ID = sys_node_id
-    CLUSTER_ID = sys_cluster_id
     RESOURCE_HEALTH_VIEW_FILE = 'resource_health_view.json'
-    RESOURCE_HEALTH_VIEW_PATH = '/tmp/'+RESOURCE_HEALTH_VIEW_FILE
+    RESOURCE_HEALTH_VIEW_PATH = '/tmp/' + RESOURCE_HEALTH_VIEW_FILE
     TEMPLATE_SCHEMA_FILE = f'/opt/seagate/{PRODUCT_FAMILY}/sspl/bin/generate_resource_health_view/resource_health_view_template.json'
 
-    NODE_REQUEST_MAP = {
-        "disk" : "Drive Slot / Bay",
-        "fan" : "Fan",
-        "psu" : "Power Supply"
-    }
-    SAS_RESOURCE_ID = "SASHBA-0"
-    node_interface_data = ['sas_port', 'network_cable']
-    NW_CBL_CARRIER_FILE = "/sys/class/net/{}/carrier"
-    
-    encl_hw_specifics_api = 'configuration'
     ENCL_MANIFEST_PATH = '/tmp/encl_manifest.json'
     NODE_MANIFEST_PATH = '/tmp/node_manifest.json'
 
     STORAGE_TYPE_JBOD = 'jbod'
-    STORAGE_TYPE_5U84 = '5u84'
+    STORAGE_TYPE_RBOD = 'rbod'
     STORAGE_TYPE_VIRTUAL = 'virtual'
-    STORAGE_TYPE_PODS = 'pods'
 
     SERVER_TYPE_VIRTUAL = 'virtual'
     SERVER_TYPE_PHYSICAL = 'physical'
 
     def __init__(self):
 
+        persistent_data_location = sys_data_path
+        storage_encl_dir = persistent_data_location + 'encl/frus/'
+        self.encl_disks_filename = storage_encl_dir + 'disks/'
+        self.encl_psus_filename = storage_encl_dir + 'psus/psudata.json'
+        self.encl_controllers_filename = storage_encl_dir + 'controllers/controllerdata.json'
+        self.encl_fans_filename = storage_encl_dir + 'fanmodules/fanmodule_data.json'
+        self.encl_sideplane_exp_filename = storage_encl_dir + 'sideplane_expanders/sideplane_expanders_data.json'
+        self.encl_logical_volumes_filename = storage_encl_dir + 'logical_volumes/logicalvolumedata.json'
+
+        self.jbod_disks_filename = persistent_data_location + 'server/systemd_watchdog/disks/disks.json'
+
+        encl_fru = 'enclosure:fru'
+        self.encl_disk_resource_type = encl_fru + ":disk"
+        self.encl_controller_resource_type = encl_fru + ":controller"
+        self.encl_fan_resource_type = encl_fru + ":fan"
+        self.encl_psu_resource_type = encl_fru + ":psu"
+        self.encl_sideplane_resource_type = encl_fru + ":sideplane"
+        self.encl_logical_volume_resource_type = f"enclosure:{PRODUCT_FAMILY}:logical_volume"
+        self.encl_sas_resource_type = "enclosure:interface:sas"
+
+        self.undesired_vals = ["N/A", ""]
+        self.NODE_REQUEST_MAP = {
+            "disk" : "Drive Slot / Bay",
+            "fan" : "Fan",
+            "psu" : "Power Supply"
+        }
+
+        self.SAS_RESOURCE_ID = "SASHBA-0"
+        self.node_interface_data = ['sas_port', 'network_cable']
+        self.NW_CBL_CARRIER_FILE = "/sys/class/net/{}/carrier"
+        
+        self.encl_hw_specifics_api = 'configuration'
+
+        self.SITE_ID = sys_site_id
+        self.RACK_ID = sys_rack_id
+        self.HOST_NAME = socket.getfqdn()
+        self.NODE_ID = sys_node_id
+        self.CLUSTER_ID = sys_cluster_id
         self.fru_id_map = None
         self.sensor_id_map = None
         self.ipmi_fru_lst = ['disk', 'fan', 'psu']
@@ -175,16 +122,8 @@ class SSPLHealthView(object):
             [self.RACK_ID] = self._resource_health_view['cluster']['sites']\
                 [self.SITE_ID]['rack'].pop('rack_id')
 
-    def run(self, parser):
-        args = parser.parse_args()
+    def run(self, args):
         health_view_created = False
-        # Display help if no or invalid args are passed in
-        if args.help or len(sys.argv) == 1 or \
-            ('--path' in sys.argv and '/' not in sys.argv[sys.argv.index('--path')+1]):
-            print('Missing arguments')
-            parser.print_help()
-            sys.exit(1)
-
         if args.path:
             self.RESOURCE_HEALTH_VIEW_PATH = args.path
             if os.path.exists(args.path):
@@ -223,7 +162,7 @@ class SSPLHealthView(object):
                 self.build_health_view_storage_jbod_cache(storage_encl_health_json)
                 health_view_created = True
             
-            elif args.encl and self.storage_type == self.STORAGE_TYPE_5U84:
+            elif args.encl and self.storage_type == self.STORAGE_TYPE_RBOD:
                 try:
                     storage_encl_health_json = self._resource_health_view['cluster']['sites']\
                                                         [self.SITE_ID]['rack'][self.RACK_ID]\
@@ -242,7 +181,7 @@ class SSPLHealthView(object):
                     print("or it is inaccessible for the current node.")
                     print("Ignored to collect enclosure health view data.")
 
-            elif self.storage_type in [self.STORAGE_TYPE_VIRTUAL, self.STORAGE_TYPE_PODS]:
+            elif self.storage_type == self.STORAGE_TYPE_VIRTUAL:
                 self._resource_health_view['cluster']['sites']\
                                                     [self.SITE_ID]['rack'][self.RACK_ID]\
                                                     ['nodes']['storage_encl'].clear()
@@ -308,7 +247,7 @@ class SSPLHealthView(object):
                 "rack_id": self.RACK_ID,
                 "node_id": self.NODE_ID
             }
-            if args.encl and args.support:
+            if args.encl and args.support and self.storage_type == self.STORAGE_TYPE_RBOD:
                 encl_support_data = {}
                 encl_support_data.update(support_common_data)
                 encl_data_response = self.build_encl_hw_specifics_instances()
@@ -1211,6 +1150,72 @@ class SSPLHealthView(object):
         smart_status = response['smart_status']['passed']
         return 'OK' if smart_status else 'Fault'
 
+    @staticmethod
+    def _update_required_data_to_consul(args):
+        
+        base_info = {'/SYSTEM_INFORMATION/site_id': 'system_information/site_id',
+                '/SYSTEM_INFORMATION/rack_id': 'system_information/rack_id',
+                '/SYSTEM_INFORMATION/node_id': f'system_information/{node_key_id}/node_id',
+                '/SYSTEM_INFORMATION/cluster_id': 'system_information/cluster_id',
+                '/SYSTEM_INFORMATION/data_path': 'system_information/data_path'}
+
+        if storage_type == 'rbod' and args.encl:
+            base_info.update({
+                '/STORAGE_ENCLOSURE/controller/primary_mc/ip': 'storage_enclosure/controller/primary_mc/ip',
+                '/STORAGE_ENCLOSURE/controller/secondary_mc/ip': 'storage_enclosure/controller/secondary_mc/ip',
+                '/STORAGE_ENCLOSURE/controller/primary_mc/port': 'storage_enclosure/controller/primary_mc/port',
+                '/STORAGE_ENCLOSURE/controller/secondary_mc/port': 'storage_enclosure/controller/secondary_mc/port',
+                '/STORAGE_ENCLOSURE/controller/user': 'storage_enclosure/controller/user',
+                '/STORAGE_ENCLOSURE/controller/secret': 'storage_enclosure/controller/password'
+            })
+        host = os.getenv('CONSUL_HOST', CONSUL_HOST)
+        port = os.getenv('CONSUL_PORT', CONSUL_PORT)
+        print(f"Consul Host : {host}")
+        print(f"Consul Port : {port}")
+        sys_site_id = SITE_ID
+        sys_rack_id = RACK_ID
+        sys_node_id = NODE_ID
+        sys_data_path = DATA_PATH
+        try:
+            consul_conn = consul.Consul(host=host, port=port)
+            for key, value in base_info.items():
+                try:
+                    consul_value = consul_conn.kv.get(value)[1]["Value"].decode()
+                    if key.endswith('site_id'):
+                        sys_site_id = consul_value
+                    elif key.endswith('rack_id'):
+                        sys_rack_id = consul_value
+                    elif key.endswith('node_id'):
+                        sys_node_id = consul_value
+                    elif key.endswith('cluster_id'):
+                        sys_cluster_id = consul_value
+                    elif key.endswith('data_path'):
+                        sys_data_path = consul_value
+                    consul_conn.kv.put(component+key, consul_value)
+
+                except TypeError as e:
+                    print(f"Unable get value from common config : {value} with error: {e}")
+                    if key.endswith('site_id'):
+                        consul_value = sys_site_id
+                    elif key.endswith('rack_id'):
+                        consul_value = sys_rack_id
+                    elif key.endswith('node_id'):
+                        consul_value = sys_node_id
+                    elif key.endswith('data_path'):
+                        consul_value = sys_data_path
+                    else:
+                        print("Exiting ...")
+                        sys.exit(os.EX_USAGE)
+                    print(f"Setting default value for {component+key} : {consul_value}")
+                    consul_conn.kv.put(component+key, consul_value)
+                print(f"Inserting common config {component+key}")
+
+            return sys_site_id, sys_rack_id, sys_node_id, sys_cluster_id, sys_data_path
+        except Exception as serror:
+            print(f"Error in connecting consul: {serror}")
+            print("Exiting ...")
+            sys.exit(os.EX_USAGE)
+
 if __name__ == "__main__":
     description = "Resource Health View Schema"
     parser = argparse.ArgumentParser(description=description, formatter_class=\
@@ -1222,5 +1227,23 @@ if __name__ == "__main__":
     parser.add_argument("--path", metavar="<path> eg. --path '/tmp/sspl/'", help="Health view\
             schema destination path (Note: Path need to be already exist)")
 
-    sys.exit(SSPLHealthView().run(parser))
+    args = parser.parse_args()
+    # Display help if no or invalid args are passed in
+    if args.help or len(sys.argv) == 1 or \
+        ('--path' in sys.argv and '/' not in sys.argv[sys.argv.index('--path')+1]):
+        print('Missing arguments')
+        parser.print_help()
+        sys.exit(1)
+    print(f"Storage Type : '{storage_type}'")
+    print(f"Server Type '{server_type}'")
 
+    if storage_type == 'virtual' and server_type == 'virtual':
+        print("Resource Health View not supported for virtual server and virtual storage deployment")
+        print("Exiting ...")
+        sys.exit(os.EX_USAGE)
+
+    sys_site_id, sys_rack_id, sys_node_id, sys_cluster_id, sys_data_path = \
+        SSPLHealthView._update_required_data_to_consul(args)
+    if storage_type == 'rbod' and args.encl:
+        from framework.platforms.realstor.realstor_enclosure import singleton_realstorencl
+    sys.exit(SSPLHealthView().run(args))


### PR DESCRIPTION
Added storage_type filter for manifest support data
Removed 5u84 and pods as storage_type and considered only rbod, virtual and jbod as storage type for the health view script

Signed-off-by: Satish Darade <satish.darade@seagate.com>

## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    Please add Problem statement here...
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Please add Problem decription here...
  </code>
</pre>
## Solution
<pre>
  <code>
    Please add summary of the change,List any dependencies that are required for this change.
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
    - [ ] No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Please describe the tests that you ran to verify your changes.
  </code>
</pre>
