### PR TITLE
EOS-13821 : Clean up old SAS_PORT_SENSOR_DATA* during post_install script

### DIFF
--- a/low-level/sspl-ll.spec
+++ b/low-level/sspl-ll.spec
@@ -143,6 +143,7 @@ systemctl stop sspl-ll.service 2> /dev/null
 rm -f /etc/polkit-1/rules.d/sspl-ll_dbus_policy.rules
 rm -f /etc/dbus-1/system.d/sspl-ll_dbus_policy.conf
 [ "$1" == "0" ] && rm -f /opt/seagate/%{product_family}/sspl/sspl_init
+rm -f /var/cortx/sspl/data/server/SAS_PORT_SENSOR_DATA*
 
 %files
 %defattr(-,sspl-ll,root,-)


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    Clean up old SAS_PORT_SENSOR_DATA* during post_install script
  </code>
</pre>
## Problem Description
<pre>
  <code>
    If the format of SAS_PORT_SENSOR_DATA* changes between two builds, it will lead to errors if SSPL uses old data from persistent storage. So it is a good idea to clean up any old data during post_install script.
  </code>
</pre>
## Solution
<pre>
  <code>
    Clean up old data after each software installation/upgrade from the post_install script.
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
    - [ ] No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Please describe the tests that you ran to verify your changes.
  </code>
</pre>
