### PR TITLE
EOS-13776: RAS: Failover/Failback downtime improvement

### DIFF
--- a/low-level/framework/utils/salt_util.py
+++ b/low-level/framework/utils/salt_util.py
@@ -27,7 +27,7 @@ except Exception as err:
     from framework.utils.utility import Utility
 
 
-class CommonConfig:
+class SaltInterface:
     """
     Interface class to get common config from common pillar using
     Provisioner API
@@ -43,7 +43,7 @@ class CommonConfig:
 
     def __init__(self):
         '''init method'''
-        if CommonConfig.__instance is None:
+        if SaltInterface.__instance is None:
             self.utility = Utility()
             self.pillar_info = None
             self.node_id = None or self.get_node_id()
@@ -55,14 +55,14 @@ class CommonConfig:
             self._is_single_node = None or self._is_server_single(_err)
             self.consul_host = None or self.get_consul_vip(_err)
             self.consul_port = None or self.get_consul_port(_err)
-            CommonConfig.__instance = self
+            SaltInterface.__instance = self
 
     @staticmethod
     def get_singleton_instance():
         '''Returns an instance of this class'''
-        if CommonConfig.__instance is None:
-            CommonConfig()
-        return CommonConfig.__instance
+        if SaltInterface.__instance is None:
+            SaltInterface()
+        return SaltInterface.__instance
 
     @staticmethod
     def get_node_id():
@@ -70,20 +70,20 @@ class CommonConfig:
 
         _node_id = 'srvnode-1'
         try:
-            with open(CommonConfig.SALT_FILE, 'r') as salt_file:
+            with open(SaltInterface.SALT_FILE, 'r') as salt_file:
                 _node_id = salt_file.read().rstrip()
-            if _node_id is None:
+            if _node_id is None or _node_id == '':
                 _node_id = 'srvnode-1'
             logger.info(f'salt_util, Server minion ID: {_node_id}')
         except OSError as err:
             if err.errno == errno.ENOENT:
                 logger.error(
                     f'Problem occured while reading from salt file. \
-                     File path: {CommonConfig.SALT_FILE} does not exist')
+                     File path: {SaltInterface.SALT_FILE} does not exist')
             elif err == errno.EACCES:
                 logger.error(
                     f'Problem occured while reading from salt file. \
-                     Permission issue while reading from: {CommonConfig.SALT_FILE}')
+                     Permission issue while reading from: {SaltInterface.SALT_FILE}')
             else:
                 logger.error(
                     f'Problem occured while reading from salt file with \
@@ -176,8 +176,8 @@ class CommonConfig:
         return _consul_port
 
 
-comm_conf = CommonConfig.get_singleton_instance()
-if comm_conf:
-    node_id = comm_conf.node_id
-    consulhost = comm_conf.consul_host
-    consulport = comm_conf.consul_port
+salt_util = SaltInterface.get_singleton_instance()
+if salt_util:
+    node_id = salt_util.node_id
+    consulhost = salt_util.consul_host
+    consulport = salt_util.consul_port

--- a/low-level/framework/utils/salt_util.py
+++ b/low-level/framework/utils/salt_util.py
@@ -71,7 +71,7 @@ class CommonConfig:
         _node_id = 'srvnode-1'
         try:
             with open(CommonConfig.SALT_FILE, 'r') as salt_file:
-                _node_id = salt_file.read()
+                _node_id = salt_file.read().rstrip()
             if _node_id is None:
                 _node_id = 'srvnode-1'
             logger.info(f'salt_util, Server minion ID: {_node_id}')

--- a/low-level/framework/utils/salt_util.py
+++ b/low-level/framework/utils/salt_util.py
@@ -13,88 +13,114 @@
 # about this software or licensing, please email opensource@seagate.com or
 # cortx-questions@seagate.com.
 
-import subprocess
+
+'''Module which provides common config information using Provisioner API'''
+
 
 try:
-    from utility import Utility
     from service_logging import logger
-except Exception as e:
-    from framework.utils.utility import Utility
+    from utility import Utility
+except Exception as err:
     from framework.utils.service_logging import logger
+    from framework.utils.utility import Utility
 
-class SaltInterface:
+
+class CommonConfig:
     """
-    Interface class to run salt commands and get values from cluster.sls
+    Interface class to get common config from common pillar using
+    Provisioner API
     """
+
+    __instance = None
+    CLUSTER_KEY = 'cluster'
+    CLUSTER_TYPE_KEY = 'type'
+    SSPL_KEY = 'sspl'
+    DATASTORE_KEY = 'DATASTORE'
 
     def __init__(self):
-        self.GRAINS_GET_NODE_CMD = "sudo salt-call grains.get id --output=newline_values_only"
-        self.MINION_GET_NODE_CMD = "cat /etc/salt/minion_id"
-        self.utility = Utility()
+        '''init method'''
+        if CommonConfig.__instance is None:
+            self.utility = Utility()
+            self.pillar_info = None
+            _result, _err, _ret_code = \
+                    self.utility.execute_cmd(['sudo', 'provisioner', 'pillar_get'])
+            _err = _err.decode("utf-8").rstrip()
+            if _ret_code == 0 and _err is '':
+                self.pillar_info = eval(_result.decode("utf-8").rstrip())
+            self.node_id = None or self.get_node_id()
+            self._is_single_node = None or self._is_single_node()
+            self.consul_host = None or self.get_consul_vip()
+            self.consul_port = None or self.get_consul_port()
+            CommonConfig.__instance = self
 
-    def get_node_id(self):
-        # TODO : need to fetch node_key using salt python API.
-        # Facing issue of service is going in loop till it eat's all the memory
-        node_key = 'srvnode-1'
+    @staticmethod
+    def get_singleton_instance():
+        '''Returns an instance of this class'''
+        if CommonConfig.__instance is None:
+            CommonConfig()
+        return CommonConfig.__instance
+
+    @staticmethod
+    def get_node_id():
+        '''Returns salt minion_id using salt config file'''
+
+        _node_id = 'srvnode-1'
         try:
-            subout = subprocess.Popen(self.GRAINS_GET_NODE_CMD, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            result = subout.stdout.readlines()
-            if result == [] or result == "":
-                logger.warning(f"Command '{self.GRAINS_GET_NODE_CMD}' failed to fetch grain id or hostname.")
-                subout = subprocess.Popen(self.MINION_GET_NODE_CMD, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                result = subout.stdout.readlines()
-                if result == [] or result == "":
-                    logger.warning(f"Command '{self.MINION_GET_NODE_CMD}' failed to fetch minion id or hostname.")
-                    logger.warning("Using node_id ('srvnode-1') as we are not able to fetch it from hostname command.")
-                    node_key = 'srvnode-1'
-                else:
-                    node_key = result[0].decode().rstrip('\n').lower()
-            else:
-                node_key = result[0].decode().rstrip('\n')
-        except Exception as e:
-            logger.warning(f"Can't read node id, using 'srvnode-1' : {e}")
-        return node_key
+            with open('/etc/salt/minion_id', 'r') as salt_file:
+                _node_id = salt_file.read()
+            if _node_id is not None:
+                _node_id = 'srvnode-1'
+        except Exception as err:
+            logger.warning(f'sspl_constants, Fail to read node-id with error: {err}, \
+                             Keeping default value as srvnode-1')
+            _node_id = 'srvnode-1'
+        return _node_id
 
-    def is_single_node(self):
+    def _is_single_node(self):
         """
         Returns true if single node, false otherwise
         """
-        is_single_node = True
+        _is_single_node = False
         try:
-            SALT_CMD = "sudo salt-call pillar.get cluster:type --output=newline_values_only"
-            subout = subprocess.Popen(SALT_CMD, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            result = subout.stdout.readlines()
-            if result == [] or result == "":
-                logger.warning("Cluster type fetch failed, assuming single node setup.")
+            if self.pillar_info:
+                cluster_type = \
+                    self.pillar_info[self.node_id][self.CLUSTER_KEY][self.CLUSTER_TYPE_KEY]
+                if cluster_type is not None and cluster_type.lower() == 'single':
+                    _is_single_node = True
             else:
-                if result[0].decode().rstrip('\n') != "single":
-                    is_single_node = False
-        except Exception as e:
-            logger.warning(f"Cluster type read failed, assuming single node setup : {e}")
-        return is_single_node
+                logger.warning(f'sspl_constants, Fail to read cluster type with \
+                               this error: {_err}, Assuming single node')
+        except Exception as err:
+            logger.warning(f'sspl_constants, Fail to read cluster type with \
+                               this error: {err}, Assuming single node')
+        logger.info(f'sspl_constants, Node type: {_is_single_node}')
+        return _is_single_node
 
-    def get_consul_vip(self, node_name):
+    def get_consul_vip(self):
         """
         Returns IP used to connect to Consul
         """
-        is_env_vm = self.utility.is_env_vm()
-        is_single_node = self.is_single_node()
+        _is_env_vm = self.utility.is_env_vm()
+        _is_single_node = self._is_single_node
         # Initialize to localhost
-        consul_vip = "127.0.0.1"
-        # Get vip if not a vm or single node, default to localhost otherwise
-        if not is_env_vm and not is_single_node:
-            # Read vip from cluster.sls
-            try:
-                SALT_CMD = f"sudo salt-call pillar.get cluster:{node_name}:network:data_nw:roaming_ip --output=newline_values_only"
-                subout = subprocess.Popen(SALT_CMD, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                result = subout.stdout.readlines()
-                if result == [] or result == "":
-                    logger.warning("Cluster VIP fetch failed, using localhost to connect to Consul.")
-                else:
-                    consul_vip = result[0].decode().rstrip('\n')
-            except Exception as e:
-                logger.warning(f"Cluster VIP read failed, using localhost to connect to Consul : {e}")
-        return consul_vip
+        _consul_vip = "127.0.0.1"
+        # Get vip if not a vm or single node, default to localhost otherwise if not _is_env_vm and not _is_single_node:
+        try:
+            if self.pillar_info is not None:
+                data_store_config = \
+                    self.pillar_info[self.node_id][self.SSPL_KEY][self.DATASTORE_KEY]
+                if data_store_config is not None:
+                    _consul_vip = data_store_config['consul_host']
+            else:
+                logger.warning(f'sspl_constants, Fail to read consul VIP with \
+                                 this error: {_err}, Assuming localhost: \
+                                 {_consul_vip} connection')
+        except Exception as err:
+            logger.warning(f'sspl_constants, Fail to read consul VIP with \
+                             this error: {err}, Assuming localhost: \
+                             {_consul_vip} connection')
+        logger.info(f'sspl_constants, consul VIP: {_consul_vip}')
+        return _consul_vip
 
     def get_consul_port(self):
         """
@@ -104,18 +130,23 @@ class SaltInterface:
         consul_port = '8500'
         # Read consul port from sspl.sls
         try:
-            SALT_CMD = f"sudo salt-call pillar.get sspl:DATASTORE:consul_port --output=newline_values_only"
-            subout = subprocess.Popen(SALT_CMD, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            result = subout.stdout.readlines()
-            if result == [] or result == "":
-                logger.warning("Consul Port fetch failed, using 8500 to connect.")
+            if self.pillar_info is not None:
+                data_store_config = \
+                    self.pillar_info[self.node_id][self.SSPL_KEY][self.DATASTORE_KEY]
+                if data_store_config is not None:
+                    consul_vip = data_store_config['consul_port']
             else:
-                consul_port = result[0].decode().rstrip('\n')
-        except Exception as e:
-            logger.warning(f"Consul Port read failed, using 8500 to connect : {e}")
+                logger.warning(f'sspl_constants, Fail to read consul VIP port with \
+                                 this error: {_err}, Assuming localhost: {consul_port} connection')
+        except Exception as err:
+            logger.warning(f'sspl_constants, Fail to read consul VIP with \
+                             this error: {err}, Assuming localhost: {consul_vip} connection')
+        logger.info(f'sspl_constants, consul port: {consul_port}')
         return consul_port
 
-salt_int = SaltInterface()
-node_id = salt_int.get_node_id()
-consulhost = salt_int.get_consul_vip(node_id)
-consulport = salt_int.get_consul_port()
+
+comm_conf = CommonConfig.get_singleton_instance()
+if comm_conf:
+    node_id = comm_conf.node_id
+    consulhost = comm_conf.consul_host
+    consulport = comm_conf.consul_port


### PR DESCRIPTION
- Use provisioner API instead of salt-call
- Make that class singleton
- Restructure

## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    EOS-13776: RAS: Failover/Failback downtime improvement
  </code>
</pre>
## Problem Description
<pre>
  <code>
    SSPL is taking more time to start in case of scenarios like failover. In case, it gets stopped for some reason.
  </code>
</pre>
## Solution
<pre>
  <code>
    SSPL is using salt-call to fetch pillar information which gets hang many times. And because of this, SSPL main thread also 
 gets blocked. So, instead of salt-call, use of provisioner API will help.
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    On dual Node setup:
    Install RPM and intialize
    Now, start the sspl resource in pacemaker cluster
    Disable the resource and enable it again
    Reboot the node
  </code>
</pre>
