### PR TITLE
EOS-13925 : Changed timeout interval from filestore to fix nw alerts …

### DIFF
--- a/low-level/files/opt/seagate/sspl/conf/sspl.conf.LDR_R1
+++ b/low-level/files/opt/seagate/sspl/conf/sspl.conf.LDR_R1
@@ -81,7 +81,7 @@ max_drivemanager_events=14
 max_drivemanager_event_interval=10
 
 [NODEDATAMSGHANDLER]
-transmit_interval=300
+transmit_interval=10
 units=MB
 # Disk Usage Threshold value in terms of usage percentage (i.e. 0 to 100)
 disk_usage_threshold=80

--- a/low-level/files/opt/seagate/sspl/conf/sspl.conf.LDR_R2
+++ b/low-level/files/opt/seagate/sspl/conf/sspl.conf.LDR_R2
@@ -93,7 +93,7 @@ max_drivemanager_events=14
 max_drivemanager_event_interval=10
 
 [NODEDATAMSGHANDLER]
-transmit_interval=300
+transmit_interval=10
 units=MB
 # Disk Usage Threshold value in terms of usage percentage (i.e. 0 to 100)
 disk_usage_threshold=80


### PR DESCRIPTION
…delay

## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    Node HW related alerts are generated in upto 5 mins
  </code>
</pre>
## Problem Description
<pre>
  <code>
    The transmit interval is set to 300 seconds in SSPL conf file
  </code>
</pre>
## Solution
<pre>
  <code>
    Reduce the transmit interval time from 300 seconds to 10 seconds
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
    - [ ] No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Please describe the tests that you ran to verify your changes.
  </code>
</pre>
