### PR TITLE
EOS-13963 : M5: Primary node replacement simulation: failed at "Apply…

### DIFF
--- a/low-level/framework/utils/salt_util.py
+++ b/low-level/framework/utils/salt_util.py
@@ -131,11 +131,10 @@ class SaltInterface:
         if not _is_env_vm or not _is_single_server:
             try:
                 if self.pillar_info is not None:
-                    data_store_config = \
-                        self.pillar_info[self.node_id][self.SSPL_KEY][self.DATASTORE_KEY]
-                    if data_store_config is not None:
-                        _consul_vip = data_store_config['consul_host']
-                    logger.info(f'salt_util, consul VIP: {_consul_vip}')
+                    _consul_vip = \
+                        self.pillar_info[self.node_id][self.CLUSTER_KEY][self.node_id]\
+                        ['network']['data_nw']['roaming_ip']
+                    logger.debug(f'salt_util, consul VIP: {_consul_vip}')
                 else:
                     logger.warning(f'salt_util, Fail to read consul VIP with \
                                      this error: {_err}, Assuming localhost: \


### PR DESCRIPTION
…ing 'components.sspl.config' on node: srvnode-1"

Signed-off-by: Mohit Pathak <mohit.pathak@seagate.com>

## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    EOS-13963
  </code>
</pre>
## Problem Description
<pre>
  <code>
    M5: Primary node replacement simulation: failed at "Applying 'components.sspl.config' on node: srvnode-1"
  </code>
</pre>
## Solution
<pre>
  <code>
    A change in Provisioner API Command
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
    - [ ] No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Please describe the tests that you ran to verify your changes.
  </code>
</pre>
