### PR TITLE
EOS-13850 5U Disk fault alerts not seen after consul disable and enable

### DIFF
--- a/low-level/framework/utils/consulstore.py
+++ b/low-level/framework/utils/consulstore.py
@@ -76,7 +76,7 @@ class ConsulStore(Store):
                 break
 
     def _consul_get(self, key, **kwargs):
-        """Load consul data from the given key"""
+        """Load consul data from the given key."""
         data = None
         status = "Failure"
 

--- a/low-level/framework/utils/consulstore.py
+++ b/low-level/framework/utils/consulstore.py
@@ -83,7 +83,7 @@ class ConsulStore(Store):
         for retry_index in range(0, MAX_CONSUL_RETRY):
             try:
                 key = self._get_key(key)
-                data = self.consul_conn.kv.get(key)[1]
+                data = self.consul_conn.kv.get(key, recurse=_opt_recurse)[1]
                 if data:
                     data = data["Value"]
                     try:

--- a/low-level/framework/utils/consulstore.py
+++ b/low-level/framework/utils/consulstore.py
@@ -82,6 +82,7 @@ class ConsulStore(Store):
 
         for retry_index in range(0, MAX_CONSUL_RETRY):
             try:
+                _opt_recurse = kwargs.get("recurse", False)
                 key = self._get_key(key)
                 data = self.consul_conn.kv.get(key, recurse=_opt_recurse)[1]
                 if data:

--- a/low-level/framework/utils/filestore.py
+++ b/low-level/framework/utils/filestore.py
@@ -129,9 +129,17 @@ class FileStore(Store):
         return value
 
     def exists(self, key):
-        """check if key exists
+        """check if key is present
         """
-        return os.path.exists(key), "Success"
+        key_present = False
+        status = "Failure"
+        try:
+            key_present = os.path.exists(key)
+            status = "Success"
+        except Exception as gerr:
+            logger.warn("Error{0} while checking if key is present".format(gerr))
+
+        return key_present, status
 
     def delete(self, key):
         """ delete a file

--- a/low-level/framework/utils/filestore.py
+++ b/low-level/framework/utils/filestore.py
@@ -131,7 +131,7 @@ class FileStore(Store):
     def exists(self, key):
         """check if key exists
         """
-        return os.path.exists(key)
+        return os.path.exists(key), "Success"
 
     def delete(self, key):
         """ delete a file

--- a/low-level/framework/utils/filestore.py
+++ b/low-level/framework/utils/filestore.py
@@ -137,7 +137,7 @@ class FileStore(Store):
             key_present = os.path.exists(key)
             status = "Success"
         except Exception as gerr:
-            logger.warn("Error{0} while checking if key is present".format(gerr))
+            logger.warn("Error while checking if {0} is present".format(gerr))
 
         return key_present, status
 

--- a/low-level/sensors/impl/generic/node_memory_fault.py
+++ b/low-level/sensors/impl/generic/node_memory_fault.py
@@ -144,7 +144,8 @@ class MemFaultSensor(SensorThread, InternalMsgQ):
     def get_stored_mem_info(self):
         """ Get the memory info from consul"""
 
-        if store.exists(self.MEM_FAULT_SENSOR_DATA):
+        path_exists, _ = store.exists(self.MEM_FAULT_SENSOR_DATA)
+        if path_exists:
             consul_data = (store.get(self.MEM_FAULT_SENSOR_DATA)).split(":")
             self.prev_mem = consul_data[0].strip()
             self.fault_alert_state = consul_data[1].strip()

--- a/low-level/sensors/impl/platforms/realstor/realstor_disk_sensor.py
+++ b/low-level/sensors/impl/platforms/realstor/realstor_disk_sensor.py
@@ -147,7 +147,7 @@ class RealStorDiskSensor(SensorThread, InternalMsgQ):
             # insertion/removal detected
             self._rss_check_disks_presence()
 
-            #Do not proceed further if latest disks info is not valid due to consul connection error
+            #Do not proceed further if latest disks info can't be validated due to store function error
             if not self.invalidate_latest_disks_info:
                 # Polling system status
                 self.rssencl.get_system_status()
@@ -155,7 +155,7 @@ class RealStorDiskSensor(SensorThread, InternalMsgQ):
                 # check for disk faults & raise if found
                 self._rss_check_disk_faults()
             else:
-                logger.warn("Ignore disk faults check due to consul error")
+                logger.warn("Can not validate disk faults or presence due to persistence store error")
 
         except Exception as ae:
             logger.exception(ae)
@@ -357,7 +357,7 @@ class RealStorDiskSensor(SensorThread, InternalMsgQ):
                         elif not path_exists and ret_val == "Success":
                             store.put(drive, dcache_path)
                         else:
-                            # Invalidate latest disks info if consul connection error is found
+                            # Invalidate latest disks info if persistence store error encountered
                             logger.warn(f"store.exists {dcache_path} return value {ret_val}")
                             self.invalidate_latest_disks_info = True
                             break


### PR DESCRIPTION
Signed-off-by: Vijay Thakkar <vijaykumar.thakkar@seagate.com>

## Problem Statement
<pre>
  <code>
    Story Ref (if any):EOS-13850 
    5U Disk fault alerts not seen after "pcs resource disable/enable consul-c1"
  </code>
</pre>
## Problem Description
<pre>
  <code>
    5U disks alerts not seen after disabling and enabling again consul agent
  </code>
</pre>
## Solution
<pre>
  <code>
    1. Data corruption was happening in the put method of consul when consul was disable and suddenly comes back during the consul connection retires. Fixed issue
    2. Also added handing to skip alerts when consul connection is down.
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Validated rpms on the hardware setup and observed that alerts are coming as per the expectation.
  </code>
</pre>
