### PR TITLE
    Changes for EOS-14128 SSPL: Need to remove ees from fillename build-ees-ha-args.yaml

### DIFF
--- a/low-level/files/opt/seagate/sspl/conf/setup.yaml
+++ b/low-level/files/opt/seagate/sspl/conf/setup.yaml
@@ -37,7 +37,7 @@ sspl:
     ha:
          script: /opt/seagate/cortx/ha/conf/script/build-ha-sspl
          args:
-            - /opt/seagate/cortx/ha/conf/build-ees-ha-args.yaml
+            - /opt/seagate/cortx/iostack-ha/conf/build-ha-args.yaml
 
     ha-cleanup:
          script: /opt/seagate/cortx/ha/conf/script/prov-ha-sspl-reset


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
    With changes in EOS-12885 and EOS-13719  the file name and path for build-ees-ha-args.yaml has changed
    This needs to be addressed in SSPL
  </code>
</pre>
## Problem Description
<pre>
  <code>
    With changes in EOS-12885 and EOS-13719  the file name and path for build-ees-ha-args.yaml has changed
    This needs to be addressed in SSPL
  </code>
</pre>
## Solution
<pre>
  <code>
    Modified the file name build-ees-ha-args.yaml to build-ha-args.yaml and updated the file path also 
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Custom build will be made with changes in all components and that will be deployed/tested  on the hardware 
  </code>
</pre>
