### PR TITLE
EOS-13850 5U Disk fault alerts not seen after consul disable and enable for main branch

### DIFF
--- a/low-level/framework/utils/filestore.py
+++ b/low-level/framework/utils/filestore.py
@@ -129,9 +129,17 @@ class FileStore(Store):
         return value
 
     def exists(self, key):
-        """check if key exists
+        """check if key is present
         """
-        return os.path.exists(key)
+        key_present = False
+        status = "Failure"
+        try:
+            key_present = os.path.exists(key)
+            status = "Success"
+        except Exception as gerr:
+            logger.warn("Error while checking if {0} is present".format(gerr))
+
+        return key_present, status
 
     def delete(self, key):
         """ delete a file

--- a/low-level/sensors/impl/generic/node_memory_fault.py
+++ b/low-level/sensors/impl/generic/node_memory_fault.py
@@ -140,7 +140,8 @@ class MemFaultSensor(SensorThread, InternalMsgQ):
     def get_stored_mem_info(self):
         """ Get the memory info from consul"""
 
-        if store.exists(self.MEM_FAULT_SENSOR_DATA):
+        path_exists, _ = store.exists(self.MEM_FAULT_SENSOR_DATA)
+        if path_exists:
             consul_data = (store.get(self.MEM_FAULT_SENSOR_DATA)).split(":")
             self.prev_mem = consul_data[0].strip()
             self.fault_alert_state = consul_data[1].strip()

--- a/low-level/sensors/impl/platforms/realstor/realstor_disk_sensor.py
+++ b/low-level/sensors/impl/platforms/realstor/realstor_disk_sensor.py
@@ -69,6 +69,7 @@ class RealStorDiskSensor(SensorThread, InternalMsgQ):
     memcache_disks = {}
     DISK_IDENTIFIER = "Disk 0."
     NUMERIC_IDENTIFIER = "numeric"
+    invalidate_latest_disks_info = False
 
     # Dependency list
     DEPENDENCIES = {
@@ -146,11 +147,15 @@ class RealStorDiskSensor(SensorThread, InternalMsgQ):
             # insertion/removal detected
             self._rss_check_disks_presence()
 
-            # Polling system status
-            self.rssencl.get_system_status()
+            #Do not proceed further if latest disks info can't be validated due to store function error
+            if not self.invalidate_latest_disks_info:
+                # Polling system status
+                self.rssencl.get_system_status()
 
-            # check for disk faults & raise if found
-            self._rss_check_disk_faults()
+                # check for disk faults & raise if found
+                self._rss_check_disk_faults()
+            else:
+                logger.warn("Can not validate disk faults or presence due to persistence store error")
 
         except Exception as ae:
             logger.exception(ae)
@@ -244,7 +249,8 @@ class RealStorDiskSensor(SensorThread, InternalMsgQ):
             #get removed drive data from disk cache
             disk_datafile = f"{self.disks_prcache}disk_{slot}.json.prev"
 
-            if not store.exists(disk_datafile):
+            path_exists, _ = store.exists(disk_datafile)
+            if not path_exists:
                 disk_datafile = f"{self.disks_prcache}disk_{slot}.json"
 
             disk_info = store.get(disk_datafile)
@@ -318,6 +324,7 @@ class RealStorDiskSensor(SensorThread, InternalMsgQ):
 
                 # reset latest drive cache to build new
                 self.latest_disks = {}
+                self.invalidate_latest_disks_info = False
 
                 for drive in drives:
                     slot = drive.get("slot", -1)
@@ -333,19 +340,31 @@ class RealStorDiskSensor(SensorThread, InternalMsgQ):
                         # If drive is replaced, previous drive info needs
                         # to be retained in disk_<slot>.json.prev file and
                         # then only dump new data to disk_<slot>.json
-                        if store.exists(dcache_path):
+                        path_exists, ret_val = store.exists(dcache_path)
+                        if path_exists and ret_val == "Success":
                             prevdrive = store.get(dcache_path)
-                            prevsn = prevdrive.get("serial-number","NA")
-                            prevhealth = prevdrive.get("health", "NA")
 
-                            if prevsn != sn or prevhealth != health:
-                                # Rename path
-                                store.put(store.get(dcache_path), dcache_path + ".prev")
-                                store.delete(dcache_path)
+                            if prevdrive is not None:
+                                prevsn = prevdrive.get("serial-number","NA")
+                                prevhealth = prevdrive.get("health", "NA")
 
-                                store.put(drive, dcache_path)
-                        else:
+                                if prevsn != sn or prevhealth != health:
+                                    # Rename path
+                                    store.put(store.get(dcache_path), dcache_path + ".prev")
+                                    store.delete(dcache_path)
+
+                                    store.put(drive, dcache_path)
+                        elif not path_exists and ret_val == "Success":
                             store.put(drive, dcache_path)
+                        else:
+                            # Invalidate latest disks info if persistence store error encountered
+                            logger.warn(f"store.exists {dcache_path} return value {ret_val}")
+                            self.invalidate_latest_disks_info = True
+                            break
+
+                if self.invalidate_latest_disks_info is True:
+                    # Reset latest disks info
+                    self.latest_disks = {}
 
             #If no in-memory cache, build from persistent cache
             if not self.memcache_disks:


### PR DESCRIPTION
Signed-off-by: Vijay Thakkar <vijaykumar.thakkar@seagate.com>

## Problem Statement
<pre>
  <code>
    Story Ref (if any):EOS-13850 
    5U Disk fault alerts not seen after "pcs resource disable/enable consul-c1"
  </code>
</pre>
## Problem Description
<pre>
  <code>
    5U disks alerts not seen after disabling and enabling again consul agent
  </code>
</pre>
## Solution
<pre>
  <code>
        1. Data corruption was happening in the put method of consul when consul was disable and suddenly comes back during the consul connection retires. Fixed issue
    2. Also added handing to skip alerts when consul connection is down.
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
    - [ ] No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Validated rpms on the hardware setup and observed that alerts are coming as per the expectation.
  </code>
</pre>
