### PR TITLE
EOS-14288: Preserve ownership when copying  and restoring cached data

### DIFF
--- a/low-level/sspl-ll.spec
+++ b/low-level/sspl-ll.spec
@@ -74,8 +74,8 @@ id -u sspl-ll &>/dev/null || {
 
 # take backup of cache folder if exists
 mkdir -p /opt/seagate/backup/%{version}
-[ -f /etc/sspl.conf ] && cp /etc/sspl.conf /opt/seagate/backup/%{version}/sspl.conf
-[ -d /var/%{product_family}/sspl ] && cp -R /var/%{product_family}/sspl /opt/seagate/backup/%{version}/
+[ -f /etc/sspl.conf ] && cp -p /etc/sspl.conf /opt/seagate/backup/%{version}/sspl.conf
+[ -d /var/%{product_family}/sspl ] && cp -Rp /var/%{product_family}/sspl /opt/seagate/backup/%{version}/
 
 # Create ras persistent cache folder
 # TODO: In production this directory will be created by provisioner
@@ -109,7 +109,7 @@ CFG_DIR=$SSPL_DIR/conf
 [ -f /tmp/sspl_tmp.conf ] && cp /tmp/sspl_tmp.conf /etc/sspl.conf
 
 # restore of data & iem folder
-[ -d /opt/seagate/backup/%{version}/sspl ] && cp -R /opt/seagate/backup/%{version}/sspl/* /var/%{product_family}/sspl/
+[ -d /opt/seagate/backup/%{version}/sspl ] && cp -Rp /opt/seagate/backup/%{version}/sspl/* /var/%{product_family}/sspl/
 
 # Copy rsyslog configuration
 # [ -f /etc/rsyslog.d/0-iemfwd.conf ] ||


### PR DESCRIPTION
Signed-off-by: Sandeep Anjara <sandeep.anjara@seagate.com>

## Problem Statement
<pre>
  <code>
    Story Ref (if any): https://jts.seagate.com/browse/EOS-14288
    Please add Problem statement here...
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Permissions are not preserved when creating backup of cached data

    -bash-4.2$ ls -l /opt/seagate/backup/1.0.0/sspl/data/
     total 8
     drwxr-xr-x 3 root root 4096 Oct  2 02:34 server
     -rw-r--r-- 1 root root   13 Oct  7 07:19 state.txt

     This creates problem when backup is restored at /var/cortx/sspl/ . SSPL can't generate files under this directory because of 
     root:root permission on cached directory and give PermissionDenied  Error when creating files.
  </code>
</pre>
## Solution
<pre>
  <code>
    Added -p flag in cp command which preserve mode,ownership,timestamps
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [x ] Yes
    - [ ] No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Please describe the tests that you ran to verify your changes.
  </code>
</pre>
