### PR TITLE
Changes for EOS-14403 Alert name issue on GUI: instead of memory alert, alert triggered as system alert.

### DIFF
--- a/low-level/json_msgs/messages/sensors/host_update.py
+++ b/low-level/json_msgs/messages/sensors/host_update.py
@@ -39,7 +39,7 @@ class HostUpdateMsg(BaseSensorMsg):
     MESSAGE_VERSION  = "1.0.0"
 
     SEVERITY = "warning"
-    RESOURCE_TYPE = "node:os:system_memory"
+    RESOURCE_TYPE = "node:os:memory_usage"
     RESOURCE_ID = "0"
 
     def __init__(self, host_id,

--- a/low-level/json_msgs/messages/sensors/host_update.py
+++ b/low-level/json_msgs/messages/sensors/host_update.py
@@ -39,7 +39,7 @@ class HostUpdateMsg(BaseSensorMsg):
     MESSAGE_VERSION  = "1.0.0"
 
     SEVERITY = "warning"
-    RESOURCE_TYPE = "node:os:system"
+    RESOURCE_TYPE = "node:os:system_memory"
     RESOURCE_ID = "0"
 
     def __init__(self, host_id,

--- a/low-level/tests/manual/mock-halon.py
+++ b/low-level/tests/manual/mock-halon.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
             },
             "sensor_request_type": {
                 "node_data": {
-                    "sensor_type": "node:os:system_memory"
+                    "sensor_type": "node:os:memory_usage"
                 }
             }
         }

--- a/low-level/tests/manual/mock-halon.py
+++ b/low-level/tests/manual/mock-halon.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
             },
             "sensor_request_type": {
                 "node_data": {
-                    "sensor_type": "node:os:system"
+                    "sensor_type": "node:os:system_memory"
                 }
             }
         }

--- a/sspl_test/alerts/os/test_node_host_data_sensor.py
+++ b/sspl_test/alerts/os/test_node_host_data_sensor.py
@@ -28,7 +28,7 @@ def init(args):
 
 def test_host_update_data_sensor(args):
     check_sspl_ll_is_running()
-    node_data_sensor_message_request("node:os:system")
+    node_data_sensor_message_request("node:os:system_memory")
     host_update_msg = None
     sleep(10)
     while not world.sspl_modules[RabbitMQingressProcessorTests.name()]._is_my_msgQ_empty():
@@ -38,7 +38,7 @@ def test_host_update_data_sensor(args):
         try:
             # Make sure we get back the message type that matches the request
             msg_type = ingressMsg.get("sensor_response_type")
-            if msg_type.get("info").get("resource_type") == "node:os:system":
+            if msg_type.get("info").get("resource_type") == "node:os:system_memory":
                 host_update_msg = msg_type
                 break
         except Exception as exception:

--- a/sspl_test/alerts/os/test_node_host_data_sensor.py
+++ b/sspl_test/alerts/os/test_node_host_data_sensor.py
@@ -28,7 +28,7 @@ def init(args):
 
 def test_host_update_data_sensor(args):
     check_sspl_ll_is_running()
-    node_data_sensor_message_request("node:os:system_memory")
+    node_data_sensor_message_request("node:os:memory_usage")
     host_update_msg = None
     sleep(10)
     while not world.sspl_modules[RabbitMQingressProcessorTests.name()]._is_my_msgQ_empty():
@@ -38,7 +38,7 @@ def test_host_update_data_sensor(args):
         try:
             # Make sure we get back the message type that matches the request
             msg_type = ingressMsg.get("sensor_response_type")
-            if msg_type.get("info").get("resource_type") == "node:os:system_memory":
+            if msg_type.get("info").get("resource_type") == "node:os:memory_usage":
                 host_update_msg = msg_type
                 break
         except Exception as exception:


### PR DESCRIPTION
…lert, alert triggered as system alert.

Modified the RESOURCE_TYPE to give more information about the resource

Signed-off-by: Archana Limaye <archana.limaye@seagate.com>

## Problem Statement
<pre>
  <code>
    Alert name was coming as system alert for the node memory alert
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Resource type node:os:system was used for the alert so it was not clear that the alert was for system memory  
  </code>
</pre>
## Solution
<pre>
  <code>
    Modified the resource type in node_data_msg_handler - HostUpdateMsg from node:os:system to node:os:system_memory
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Created the RPM ; generated the memory alert and confirmed on rabbitmq_reader that the new  reource_type is displayed in the alert alert 
  </code>
</pre>
