### PR TITLE
EOS-14380: Remove dependency of Consul hardcoded path inside Hare and move to /usr/bin/consul - SSPL - (main)

### DIFF
--- a/low-level/files/opt/seagate/sspl/bin/constants.sh
+++ b/low-level/files/opt/seagate/sspl/bin/constants.sh
@@ -26,7 +26,6 @@ SSPL_STORE_TYPE="consul"
 CONSUL_HOST="127.0.0.1"
 CONSUL_PORT="8500"
 ENVIRONMENT="PROD"
-CONSUL_PATH="/opt/seagate/$PRODUCT_FAMILY/hare/bin"
-CONSUL_FALLBACK_PATH="/opt/seagate/$PRODUCT_FAMILY/sspl/bin"
+CONSUL_PATH="/usr/bin/"
 # This file will be created when sspl is being configured for node replacement case
 REPLACEMENT_NODE_ENV_VAR_FILE="/etc/profile.d/set_replacement_env.sh"

--- a/low-level/files/opt/seagate/sspl/bin/sspl_setup_consul
+++ b/low-level/files/opt/seagate/sspl/bin/sspl_setup_consul
@@ -29,7 +29,6 @@ SCRIPT_DIR=$(dirname $0)
 SCRIPT_NAME=$(basename $0)
 
 mkdir -p $CONSUL_PATH
-mkdir -p $CONSUL_FALLBACK_PATH
 
 
 usage() {
@@ -51,7 +50,6 @@ while getopts ":e:" OPTION; do
     esac
 done
 
-# Look consul in fallback path if not available in CONSUL_PATH
 if ! [ -x "$(command -v $CONSUL_PATH/consul)" ]; then
     # For Dev environment, install consul
     if [ "$ENVIRONMENT" == 'DEV' ]; then
@@ -64,10 +62,8 @@ if ! [ -x "$(command -v $CONSUL_PATH/consul)" ]; then
         fi
         unzip consul_1.7.0_linux_amd64.zip
         rm -rf consul_1.7.0_linux_amd64.zip
-        mv ./consul $CONSUL_FALLBACK_PATH/consul
+        mv ./consul $CONSUL_PATH
     fi
-
-    ln -sv $CONSUL_FALLBACK_PATH/consul $CONSUL_PATH/consul
 
     if ! [ -x "$(command -v $CONSUL_PATH/consul)" ]; then
         echo "Consul is not available, exiting..";

--- a/sspl_test/constants.sh
+++ b/sspl_test/constants.sh
@@ -15,5 +15,4 @@
 
 PRODUCT_NAME='LDR_R1'
 PRODUCT_FAMILY='cortx'
-CONSUL_PATH="/opt/seagate/$PRODUCT_FAMILY/hare/bin"
-CONSUL_FALLBACK_PATH="/opt/seagate/$PRODUCT_FAMILY/sspl/bin"
+CONSUL_PATH="/usr/bin/"

--- a/sspl_test/framework/base/sspl_constants.py
+++ b/sspl_test/framework/base/sspl_constants.py
@@ -28,7 +28,7 @@ DATA_PATH = f"/var/{PRODUCT_FAMILY}/sspl/data/"
 SSPL_STORE_TYPE = 'consul'
 CONSUL_HOST = '127.0.0.1'
 CONSUL_PORT = '8500'
-CONSUL_PATH = f"/opt/seagate/{PRODUCT_FAMILY}/hare/bin"
+CONSUL_PATH = '/usr/bin/'
 
 # required only for init
 component = 'sspl_test/config'
@@ -67,12 +67,12 @@ if __name__ == "__main__":
     print(' '.join(enabled_products))
 
 # Consul paths for enclosure connection
-GET_USERNAME = "/opt/seagate/cortx/hare/bin/consul kv get sspl/config/STORAGE_ENCLOSURE/controller/user"
-GET_PASSWD = "/opt/seagate/cortx/hare/bin/consul kv get sspl/config/STORAGE_ENCLOSURE/controller/secret"
-GET_PRIMARY_IP = "/opt/seagate/cortx/hare/bin/consul kv get sspl/config/STORAGE_ENCLOSURE/controller/primary_mc/ip"
-GET_PRIMARY_PORT = "/opt/seagate/cortx/hare/bin/consul kv get sspl/config/STORAGE_ENCLOSURE/controller/primary_mc/port"
-GET_SECONDARY_IP = "/opt/seagate/cortx/hare/bin/consul kv get sspl/config/STORAGE_ENCLOSURE/controller/secondary_mc/ip"
-GET_SECONDARY_PORT = "/opt/seagate/cortx/hare/bin/consul kv get sspl/config/STORAGE_ENCLOSURE/controller/secondary_mc/port"
-GET_CLUSTER_ID = "/opt/seagate/cortx/hare/bin/consul kv get sspl/config/SYSTEM_INFORMATION/cluster_id"
+GET_USERNAME = CONSUL_PATH + "consul kv get sspl/config/STORAGE_ENCLOSURE/controller/user"
+GET_PASSWD = CONSUL_PATH + "consul kv get sspl/config/STORAGE_ENCLOSURE/controller/secret"
+GET_PRIMARY_IP = CONSUL_PATH + "consul kv get sspl/config/STORAGE_ENCLOSURE/controller/primary_mc/ip"
+GET_PRIMARY_PORT = CONSUL_PATH + "consul kv get sspl/config/STORAGE_ENCLOSURE/controller/primary_mc/port"
+GET_SECONDARY_IP = CONSUL_PATH + "consul kv get sspl/config/STORAGE_ENCLOSURE/controller/secondary_mc/ip"
+GET_SECONDARY_PORT = CONSUL_PATH + "consul kv get sspl/config/STORAGE_ENCLOSURE/controller/secondary_mc/port"
+GET_CLUSTER_ID = CONSUL_PATH + "consul kv get sspl/config/SYSTEM_INFORMATION/cluster_id"
 
 SSPL_TEST_PATH = "/opt/seagate/cortx/sspl/sspl_test"

--- a/util-scripts/sspl_dev_cfg_update_in_consul
+++ b/util-scripts/sspl_dev_cfg_update_in_consul
@@ -42,7 +42,7 @@ sspl_conf_update=(
 )
 
 for conf_val in "${!sspl_conf_update[@]}";
-    do /opt/seagate/cortx/hare/bin/consul kv put $conf_val ${sspl_conf_update[$conf_val]}; echo ${sspl_conf_update[$conf_val]}
+    do /usr/bin/consul kv put $conf_val ${sspl_conf_update[$conf_val]}; echo ${sspl_conf_update[$conf_val]}
 done
 
 echo "Restarting SSPL"


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
    Story Ref (if any):
Consul installation and binaries are moved out of Hare and is part of provisioner for installation. Please refer to ticket EOS-14262 for more information.

As a workaround, a symlink is created to /opt/seagate/cortx/hare/bin/consul for product to continue to work. This ticket is for component to remove the dependency on hare path hardcoded in the code so that symlink can be removed.

If it is already done in your component then mark this ticket resolved not required anymore.

Once all required components have made the changes. The code for creating the symlink during installation will be removed and no workaround required for consul binaries.
  
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Provisioner installs consul and binary will be available in /usr/bin
  </code>
</pre>
## Solution
<pre>
  <code>
    CONSUL_PATH="/usr/bin/"
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - Yes
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Please describe the tests that you ran to verify your changes.
  </code>
</pre>
