### PR TITLE
EOS-13209 : eos-13209-main-Add-retry-in-controller-login-during-healthview-generation

### DIFF
--- a/low-level/files/opt/seagate/sspl/bin/generate_resource_health_view/resource_health_view
+++ b/low-level/files/opt/seagate/sspl/bin/generate_resource_health_view/resource_health_view
@@ -868,6 +868,7 @@ class SSPLHealthView(object):
         if response.status_code != singleton_realstorencl.ws.HTTP_OK:
             if (response.status_code == singleton_realstorencl.ws.HTTP_TIMEOUT or \
                 response.status_code == singleton_realstorencl.ws.HTTP_CONN_REFUSED or \
+                response.status_code == singleton_realstorencl.ws.HTTP_FORBIDDEN or \
                 response.status_code == singleton_realstorencl.ws.HTTP_NO_ROUTE_TO_HOST) \
                 and self.tried_alt_ip is False:
                 print("Retrying to fetch data from another mc IP....: {}".format(singleton_realstorencl.active_ip))

--- a/low-level/files/opt/seagate/sspl/bin/generate_resource_health_view/resource_health_view
+++ b/low-level/files/opt/seagate/sspl/bin/generate_resource_health_view/resource_health_view
@@ -101,7 +101,6 @@ class SSPLHealthView(object):
         self.sensor_id_map = None
         self.ipmi_fru_lst = ['disk', 'fan', 'psu']
         self.sensor_list = ['temperature', 'current', 'voltage']
-        self.tried_alt_ip = False
         self.correct_mc_config = True
         self.storage_type = storage_type
         self.server_type = server_type
@@ -865,19 +864,9 @@ class SSPLHealthView(object):
             show_fru = "/show/configuration"
 
         response = self.fetch_ws_request_data(show_fru, fru)
-        if response.status_code != singleton_realstorencl.ws.HTTP_OK:
-            if (response.status_code == singleton_realstorencl.ws.HTTP_TIMEOUT or \
-                response.status_code == singleton_realstorencl.ws.HTTP_CONN_REFUSED or \
-                response.status_code == singleton_realstorencl.ws.HTTP_FORBIDDEN or \
-                response.status_code == singleton_realstorencl.ws.HTTP_NO_ROUTE_TO_HOST) \
-                and self.tried_alt_ip is False:
-                print("Retrying to fetch data from another mc IP....: {}".format(singleton_realstorencl.active_ip))
-                singleton_realstorencl.login()
-                self.tried_alt_ip = True
-                response = self.fetch_ws_request_data(show_fru, fru)
-
-        if response.status_code != singleton_realstorencl.ws.HTTP_OK and self.tried_alt_ip is True:
-            self.correct_mc_config = False
+        if not response or response.status_code != singleton_realstorencl.ws.HTTP_OK:
+            if singleton_realstorencl.active_ip == singleton_realstorencl.mc2:
+                self.correct_mc_config = False
             return []
         else:
             response_data = json.loads(response.text)

--- a/low-level/files/opt/seagate/sspl/bin/sspl_provisioner_init
+++ b/low-level/files/opt/seagate/sspl/bin/sspl_provisioner_init
@@ -88,7 +88,8 @@ setup_provisioner_prereq(){
 
     # to install updated packages
     pkg_name="cortx-prvsnr-cli-1.0.0"
-    build_url="http://cortx-storage.colo.seagate.com/releases/cortx/github/dev/rhel-7.7.1908/provisioner_last_successful"
+    # build_url="http://cortx-storage.colo.seagate.com/releases/cortx/github/dev/rhel-7.7.1908/provisioner_last_successful"
+    build_url="http://cortx-storage.colo.seagate.com/releases/cortx/github/release/rhel-7.7.1908/last_successful/"
     yum install -y $build_url/$(curl -s $build_url/|grep $pkg_name|sed 's/<\/*[^"]*"//g'|cut -d"\"" -f1)
     # provisioner decides the setup(single or dual node) for deployment and
     # they don't use this dev init script. This script supports only single node setup.

--- a/low-level/framework/platforms/realstor/realstor_enclosure.py
+++ b/low-level/framework/platforms/realstor/realstor_enclosure.py
@@ -239,7 +239,7 @@ class RealStorEnclosure(StorageEnclosure):
                 try:
                     jresponse = json.loads(response.content)
 
-                    #TODO: Need a way to check return-code 2 in more optimal way if possible, 
+                    #TODO: Need a way to check return-code 2 in more optimal way if possible,
                     # currently being checked for all http 200 responses
                     if jresponse:
 

--- a/low-level/framework/platforms/realstor/realstor_enclosure.py
+++ b/low-level/framework/platforms/realstor/realstor_enclosure.py
@@ -38,7 +38,7 @@ class RealStorEnclosure(StorageEnclosure):
     DEFAULT_MC_IP = "127.0.0.1"
     WEBSERVICE_TIMEOUT = 20
     PERSISTENT_DATA_UPDATE_TIMEOUT = 5
-    MAX_RETRIES = 1
+    MAX_RETRIES = 2
 
     CONF_SECTION_MC = "STORAGE_ENCLOSURE"
     SYSTEM_INFORMATION = "SYSTEM_INFORMATION"
@@ -75,8 +75,11 @@ class RealStorEnclosure(StorageEnclosure):
     URI_CLIAPI_SHOWVERSION = "/show/version/detail"
     URI_CLIAPI_BASE = "/"
     URI_CLIAPI_DOWNLOADDEBUGDATA = "/downloadDebugData"
-
     URL_ENCLLOGS_POSTDATA = "/api/collectDebugData"
+
+    # CLI APIs Response status strings
+    CLIAPI_RESP_INVSESSION = "Invalid sessionkey"
+    CLIAPI_RESP_FAILURE = 2
 
     # Realstor generic health states
     HEALTH_OK = "ok"
@@ -203,17 +206,23 @@ class RealStorEnclosure(StorageEnclosure):
             self.active_ip = self.mc1
             self.active_wsport = self.mc1_wsport
 
-        logger.debug("Current MC active ip {0}, active wsport {1}\
+        self.login()
+        logger.debug("Current MC active ip {0}, active wsport {1}. Logged-in\
             ".format(self.active_ip, self.active_wsport))
 
     def ws_request(self, url, method, retry_count=MAX_RETRIES,
             post_data=""):
         """Make webservice requests using common utils"""
         response = None
-        relogin = False
+        retried_login = False
+        need_relogin = False
         tried_alt_ip = False
 
         while retry_count:
+            if tried_alt_ip:
+                # Extract show fru name from old URL to update alternative IP.
+                url = self.build_url(url[url.index('/api/'):].replace('/api',''))
+
             response = self.ws.ws_request(method, url,
                        self.common_reqheaders, post_data,
                        self.WEBSERVICE_TIMEOUT)
@@ -223,27 +232,46 @@ class RealStorEnclosure(StorageEnclosure):
             if response is None:
                 continue
 
-            if response.status_code != self.ws.HTTP_OK:
+            if response.status_code == self.ws.HTTP_OK:
 
-                # if call fails with invalid session key request or http 403
-                # forbidden request, login & retry
-                if response.status_code == self.ws.HTTP_FORBIDDEN and relogin is False:
-                    logger.info("%s failed, retrying after login " % (url))
-
-                    self.login()
-                    relogin = True
-                    continue
-
-                elif (response.status_code == self.ws.HTTP_TIMEOUT or \
-                         response.status_code == self.ws.HTTP_CONN_REFUSED or \
-                         response.status_code == self.ws.HTTP_NO_ROUTE_TO_HOST) \
-                         and tried_alt_ip is False:
-                    self.switch_to_alt_mc()
-                    tried_alt_ip = True
-                    self.mc_timeout_counter += 1
-                    continue
-            else:
                 self.mc_timeout_counter = 0
+
+                try:
+                    jresponse = json.loads(response.content)
+
+                    #TODO: Need a way to check return-code 2 in more optimal way if possible, 
+                    # currently being checked for all http 200 responses
+                    if jresponse:
+
+                        if jresponse['status'][0]['return-code'] == self.CLIAPI_RESP_FAILURE:
+                            response_status = jresponse['status'][0]['response']
+
+                            # if call fails with invalid session key request
+                            # seen in G280 fw version
+                            if self.CLIAPI_RESP_INVSESSION in response_status:
+                               need_relogin = True
+
+                except ValueError as badjson:
+                    logger.error("%s returned mal-formed json:\n%s" % (url, badjson))
+
+            # http 403 forbidden request, login & retry
+            elif (response.status_code == self.ws.HTTP_FORBIDDEN or \
+                need_relogin) and retried_login is False:
+                logger.info("%s failed, retrying after login " % (url))
+
+                self.login()
+                retried_login = True
+                need_relogin = False
+                continue
+
+            elif (response.status_code == self.ws.HTTP_TIMEOUT or \
+                     response.status_code == self.ws.HTTP_CONN_REFUSED or \
+                     response.status_code == self.ws.HTTP_NO_ROUTE_TO_HOST) \
+                     and tried_alt_ip is False:
+                self.switch_to_alt_mc()
+                tried_alt_ip = True
+                self.mc_timeout_counter += 1
+                continue
 
             break
 
@@ -279,6 +307,7 @@ class RealStorEnclosure(StorageEnclosure):
             logger.error("%s returned mal-formed json:\n%s" % (url, badjson))
 
         if jresponse:
+
             if jresponse['status'][0]['return-code'] == 1:
                 sessionKey = jresponse['status'][0]['response']
                 self._add_request_headers(sessionKey)


### PR DESCRIPTION
Signed-off-by: Satish Darade <satish.darade@seagate.com>

## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    Health view script is failing when forbidden error came from cotroller api's
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Health view script is failing when forbidden error came from cotroller api's
  </code>
</pre>
## Solution
<pre>
  <code>
    Added some more validation checks to retry in controller login during hel tview generation
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
  </code>
</pre>
