### PR TITLE
EOS-14617

### DIFF
--- a/low-level/files/opt/seagate/sspl/bin/consuldump.py
+++ b/low-level/files/opt/seagate/sspl/bin/consuldump.py
@@ -42,7 +42,8 @@ class ConsulDump():
                 print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                 time.sleep(WAIT_BEFORE_RETRY)
             except Exception as gerr:
-                if 'No cluster leader' in gerr:
+                gerr = str(gerr)
+                if 'no cluster leader' in gerr.lower():
                     print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:
@@ -77,7 +78,8 @@ class ConsulDump():
                 print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                 time.sleep(WAIT_BEFORE_RETRY)
             except Exception as gerr:
-                if 'No cluster leader' in gerr:
+                gerr = str(gerr)
+                if 'no cluster leader' in gerr.lower():
                     print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:

--- a/low-level/files/opt/seagate/sspl/bin/consuldump.py
+++ b/low-level/files/opt/seagate/sspl/bin/consuldump.py
@@ -42,7 +42,7 @@ class ConsulDump():
                 print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                 time.sleep(WAIT_BEFORE_RETRY)
             except Exception as gerr:
-                if 'no cluster leader' in gerr.lower():
+                if 'No cluster leader' in gerr:
                     print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:
@@ -77,7 +77,7 @@ class ConsulDump():
                 print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                 time.sleep(WAIT_BEFORE_RETRY)
             except Exception as gerr:
-                if 'no cluster leader' in gerr.lower():
+                if 'No cluster leader' in gerr:
                     print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:

--- a/low-level/files/opt/seagate/sspl/bin/consuldump.py
+++ b/low-level/files/opt/seagate/sspl/bin/consuldump.py
@@ -42,8 +42,12 @@ class ConsulDump():
                 print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                 time.sleep(WAIT_BEFORE_RETRY)
             except Exception as gerr:
-                print(f'Error[{gerr}] consul error')
-                break
+                if 'no cluster leader' in gerr.lower():
+                    print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
+                    time.sleep(WAIT_BEFORE_RETRY)
+                else:
+                    print(f'Error[{gerr}] consul error')
+                    break
 
     def get_dir(self):
         if not self.existing:
@@ -73,8 +77,12 @@ class ConsulDump():
                 print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                 time.sleep(WAIT_BEFORE_RETRY)
             except Exception as gerr:
-                print(f'Error{gerr} while reading data from consul {key}')
-                break
+                if 'no cluster leader' in gerr.lower():
+                    print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
+                    time.sleep(WAIT_BEFORE_RETRY)
+                else:
+                    print(f'Error{gerr} while reading data from consul {key}')
+                    break
         return value
 
     def get_pretty_file_content(self, data):

--- a/low-level/files/opt/seagate/sspl/bin/consuldump.py
+++ b/low-level/files/opt/seagate/sspl/bin/consuldump.py
@@ -27,6 +27,8 @@ from sspl_constants import MAX_CONSUL_RETRY, WAIT_BEFORE_RETRY, CONSUL_HOST, CON
 
 class ConsulDump():
 
+    Err_string = '500 No cluster leader'
+
     def __init__(self, localtion=os.getcwd(), dir_prefix="", existing=False, name=None, keys={}):
         self.time = str(int(time.time()))
         self.dir_prefix = dir_prefix
@@ -42,8 +44,8 @@ class ConsulDump():
                 print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                 time.sleep(WAIT_BEFORE_RETRY)
             except Exception as gerr:
-                gerr = str(gerr)
-                if 'no cluster leader' in gerr.lower():
+                consulerr = str(gerr)
+                if self.Err_string == consulerr:
                     print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:
@@ -78,8 +80,8 @@ class ConsulDump():
                 print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                 time.sleep(WAIT_BEFORE_RETRY)
             except Exception as gerr:
-                gerr = str(gerr)
-                if 'no cluster leader' in gerr.lower():
+                consulerr = str(gerr)
+                if self.Err_string == consulerr:
                     print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:

--- a/low-level/files/opt/seagate/sspl/bin/consuldump.py
+++ b/low-level/files/opt/seagate/sspl/bin/consuldump.py
@@ -23,11 +23,9 @@ import json
 import argparse
 import time
 import requests
-from sspl_constants import MAX_CONSUL_RETRY, WAIT_BEFORE_RETRY, CONSUL_HOST, CONSUL_PORT
+from sspl_constants import MAX_CONSUL_RETRY, WAIT_BEFORE_RETRY, CONSUL_HOST, CONSUL_PORT, CONSUL_ERR_STRING
 
 class ConsulDump():
-
-    Err_string = '500 No cluster leader'
 
     def __init__(self, localtion=os.getcwd(), dir_prefix="", existing=False, name=None, keys={}):
         self.time = str(int(time.time()))
@@ -44,8 +42,9 @@ class ConsulDump():
                 print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                 time.sleep(WAIT_BEFORE_RETRY)
             except Exception as gerr:
+                # TODO: optimize the if-else here and wherever this similar code is used
                 consulerr = str(gerr)
-                if self.Err_string == consulerr:
+                if CONSUL_ERR_STRING == consulerr:
                     print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:
@@ -81,7 +80,7 @@ class ConsulDump():
                 time.sleep(WAIT_BEFORE_RETRY)
             except Exception as gerr:
                 consulerr = str(gerr)
-                if self.Err_string == consulerr:
+                if CONSUL_ERR_STRING == consulerr:
                     print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:

--- a/low-level/framework/base/sspl_constants.py
+++ b/low-level/framework/base/sspl_constants.py
@@ -52,6 +52,7 @@ ENCL_DOWNLOAD_LOG_WAIT_BEFORE_RETRY = 15
 node_key_id = node_id
 CONSUL_HOST = consulhost
 CONSUL_PORT = consulport
+CONSUL_ERR_STRING = '500 No cluster leader'
 SSPL_SETTINGS = {
         "ACTUATORS" : ["Service", "RAIDactuator", "Smartctl", "NodeHWactuator", "RealStorActuator"],
         "CORE_PROCESSORS" : ("RabbitMQegressProcessor", "RabbitMQingressProcessor", "LoggingProcessor"),

--- a/low-level/framework/rabbitmq/rabbitmq_egress_processor.py
+++ b/low-level/framework/rabbitmq/rabbitmq_egress_processor.py
@@ -300,7 +300,7 @@ class RabbitMQegressProcessor(ScheduledModuleThread, InternalMsgQ):
                     logger.error("RabbitMQegressProcessor, _transmit_msg_on_exchange, rabbitmq connectivity lost, adding message to consul %s" % self._jsonMsg)
                     store_queue.put(jsonMsg)
                 except Exception as err:
-                    logger.error("RabbitMQegressProcessor, _transmit_msg_on_exchange, some problem while publishing the message, adding message to consul %s" % self._jsonMsg)
+                    logger.error("RabbitMQegressProcessor, _transmit_msg_on_exchange, Unknown error while publishing the message, adding to persistent store %s" % self._jsonMsg)
                     store_queue.put(jsonMsg)
 
             # No exceptions thrown so success

--- a/low-level/framework/rabbitmq/rabbitmq_egress_processor.py
+++ b/low-level/framework/rabbitmq/rabbitmq_egress_processor.py
@@ -308,6 +308,7 @@ class RabbitMQegressProcessor(ScheduledModuleThread, InternalMsgQ):
 
         except Exception as ex:
             logger.error("RabbitMQegressProcessor, _transmit_msg_on_exchange: %r" % ex)
+            store_queue.put(jsonMsg)
 
     def shutdown(self):
         """Clean up scheduler queue and gracefully shutdown thread"""

--- a/low-level/framework/rabbitmq/rabbitmq_egress_processor.py
+++ b/low-level/framework/rabbitmq/rabbitmq_egress_processor.py
@@ -299,6 +299,9 @@ class RabbitMQegressProcessor(ScheduledModuleThread, InternalMsgQ):
                 except connection_exceptions:
                     logger.error("RabbitMQegressProcessor, _transmit_msg_on_exchange, rabbitmq connectivity lost, adding message to consul %s" % self._jsonMsg)
                     store_queue.put(jsonMsg)
+                except Exception as err:
+                    logger.error("RabbitMQegressProcessor, _transmit_msg_on_exchange, some problem while publishing the message, adding message to consul %s" % self._jsonMsg)
+                    store_queue.put(jsonMsg)
 
             # No exceptions thrown so success
             self._log_debug("_transmit_msg_on_exchange, Successfully Sent: %s" % self._jsonMsg)
@@ -307,7 +310,7 @@ class RabbitMQegressProcessor(ScheduledModuleThread, InternalMsgQ):
                 self._event.set()
 
         except Exception as ex:
-            logger.error("RabbitMQegressProcessor, _transmit_msg_on_exchange: %r" % ex)
+            logger.error(f'RabbitMQegressProcessor, _transmit_msg_on_exchange, problem while publishing the message:{ex}, adding message to consul: {self._jsonMsg}')
             store_queue.put(jsonMsg)
 
     def shutdown(self):

--- a/low-level/framework/rabbitmq/rabbitmq_egress_processor.py
+++ b/low-level/framework/rabbitmq/rabbitmq_egress_processor.py
@@ -311,7 +311,6 @@ class RabbitMQegressProcessor(ScheduledModuleThread, InternalMsgQ):
 
         except Exception as ex:
             logger.error(f'RabbitMQegressProcessor, _transmit_msg_on_exchange, problem while publishing the message:{ex}, adding message to consul: {self._jsonMsg}')
-            store_queue.put(jsonMsg)
 
     def shutdown(self):
         """Clean up scheduler queue and gracefully shutdown thread"""

--- a/low-level/framework/utils/config_reader.py
+++ b/low-level/framework/utils/config_reader.py
@@ -67,7 +67,7 @@ class ConfigReader(object):
                     print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 except Exception as gerr:
-                    if 'no cluster leader' in gerr.lower():
+                    if 'No cluster leader' in gerr:
                         print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                         time.sleep(WAIT_BEFORE_RETRY)
                     else:
@@ -289,7 +289,7 @@ class ConfigReader(object):
                 print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                 time.sleep(WAIT_BEFORE_RETRY)
             except Exception as gerr:
-                if 'no cluster leader' in gerr.lower():
+                if 'No cluster leader' in gerr:
                     print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:

--- a/low-level/framework/utils/config_reader.py
+++ b/low-level/framework/utils/config_reader.py
@@ -67,7 +67,8 @@ class ConfigReader(object):
                     print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 except Exception as gerr:
-                    if 'No cluster leader' in gerr:
+                    gerr = str(gerr)
+                    if 'no cluster leader' in gerr.lower():
                         print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                         time.sleep(WAIT_BEFORE_RETRY)
                     else:
@@ -289,7 +290,8 @@ class ConfigReader(object):
                 print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                 time.sleep(WAIT_BEFORE_RETRY)
             except Exception as gerr:
-                if 'No cluster leader' in gerr:
+                gerr = str(gerr)
+                if 'no cluster leader' in gerr.lower():
                     print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:

--- a/low-level/framework/utils/config_reader.py
+++ b/low-level/framework/utils/config_reader.py
@@ -34,7 +34,7 @@ try:
 except Exception as e:
     from framework.base.sspl_constants import component, salt_provisioner_pillar_sls, \
          SSPL_STORE_TYPE, StoreTypes, salt_uniq_passwd_per_node, COMMON_CONFIGS, SSPL_CONFIGS, \
-         MAX_CONSUL_RETRY, WAIT_BEFORE_RETRY
+         MAX_CONSUL_RETRY, WAIT_BEFORE_RETRY, CONSUL_ERR_STRING
     from framework.utils.consulstore import ConsulStore
     from framework.utils.filestore import FileStore
 
@@ -47,7 +47,6 @@ class ConfigReader(object):
     NoSectionError              = configparser.NoSectionError
     NoOptionError               = configparser.NoOptionError
     Error                       = configparser.Error
-    Err_string = '500 No cluster leader'
 
     def __init__(self, is_init=False, is_test=False, test_config_path=None):
         """Constructor for ConfigReader
@@ -69,7 +68,7 @@ class ConfigReader(object):
                     time.sleep(WAIT_BEFORE_RETRY)
                 except Exception as gerr:
                     consulerr = str(gerr)
-                    if self.Err_string == consulerr:
+                    if CONSUL_ERR_STRING == consulerr:
                         print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                         time.sleep(WAIT_BEFORE_RETRY)
                     else:
@@ -292,7 +291,7 @@ class ConfigReader(object):
                 time.sleep(WAIT_BEFORE_RETRY)
             except Exception as gerr:
                 consulerr = str(gerr)
-                if self.Err_string == consulerr:
+                if CONSUL_ERR_STRING == consulerr:
                     print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:

--- a/low-level/framework/utils/config_reader.py
+++ b/low-level/framework/utils/config_reader.py
@@ -67,8 +67,12 @@ class ConfigReader(object):
                     print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 except Exception as gerr:
-                    print(f'Error[{gerr}] consul error')
-                    break
+                    if 'no cluster leader' in gerr.lower():
+                        print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
+                        time.sleep(WAIT_BEFORE_RETRY)
+                    else:
+                        print(f'Error[{gerr}] consul error')
+                        break
         elif is_test:
             self.read_test_conf(test_config_path)
         else:
@@ -285,6 +289,10 @@ class ConfigReader(object):
                 print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                 time.sleep(WAIT_BEFORE_RETRY)
             except Exception as gerr:
-                print(f'Error{gerr} while reading data from consul {key}')
-                break
+                if 'no cluster leader' in gerr.lower():
+                    print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
+                    time.sleep(WAIT_BEFORE_RETRY)
+                else:
+                    print(f'Error{gerr} while reading data from consul {key}')
+                    break
         return data

--- a/low-level/framework/utils/config_reader.py
+++ b/low-level/framework/utils/config_reader.py
@@ -47,6 +47,7 @@ class ConfigReader(object):
     NoSectionError              = configparser.NoSectionError
     NoOptionError               = configparser.NoOptionError
     Error                       = configparser.Error
+    Err_string = '500 No cluster leader'
 
     def __init__(self, is_init=False, is_test=False, test_config_path=None):
         """Constructor for ConfigReader
@@ -67,8 +68,8 @@ class ConfigReader(object):
                     print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 except Exception as gerr:
-                    gerr = str(gerr)
-                    if 'no cluster leader' in gerr.lower():
+                    consulerr = str(gerr)
+                    if self.Err_string == consulerr:
                         print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                         time.sleep(WAIT_BEFORE_RETRY)
                     else:
@@ -290,8 +291,8 @@ class ConfigReader(object):
                 print(f'Error[{connerr}] consul connection refused Retry Index {retry_index}')
                 time.sleep(WAIT_BEFORE_RETRY)
             except Exception as gerr:
-                gerr = str(gerr)
-                if 'no cluster leader' in gerr.lower():
+                consulerr = str(gerr)
+                if self.Err_string == consulerr:
                     print(f'Error[{gerr}] consul connection refused Retry Index {retry_index}')
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:

--- a/low-level/framework/utils/consulstore.py
+++ b/low-level/framework/utils/consulstore.py
@@ -100,9 +100,14 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                logger.warn("Error[{0}] while reading data from consul {1}" \
-                    .format(gerr, key))
-                break
+                if 'no cluster leader' in gerr.lower():
+                    logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
+                        .format(connerr, retry_index))
+                    time.sleep(WAIT_BEFORE_RETRY)
+                else:
+                    logger.warn("Error[{0}] while reading data from consul {1}" \
+                        .format(gerr, key))
+                    break
 
         return data, status
 

--- a/low-level/framework/utils/consulstore.py
+++ b/low-level/framework/utils/consulstore.py
@@ -30,6 +30,8 @@ import requests
 
 class ConsulStore(Store):
 
+    Err_string = '500 No cluster leader'
+
     def __init__(self, host, port):
         super(Store, self).__init__()
         for retry_index in range(0, MAX_CONSUL_RETRY):
@@ -43,8 +45,8 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                gerr = str(gerr)
-                if 'no cluster leader' in gerr.lower():
+                consuerr = str(gerr)
+                if self.Err_string == consuerr:
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -77,8 +79,8 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                gerr = str(gerr)
-                if 'no cluster leader' in gerr.lower():
+                consulerr = str(gerr)
+                if self.Err_string == consulerr:
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -112,8 +114,8 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                gerr = str(gerr)
-                if 'no cluster leader' in gerr.lower():
+                consulerr = str(gerr)
+                if self.Err_string == consulerr:
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -155,8 +157,8 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                gerr = str(gerr)
-                if 'no cluster leader' in gerr.lower():
+                consulerr = str(gerr)
+                if self.Err_string == consulerr:
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -184,8 +186,8 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                gerr = str(gerr)
-                if 'no cluster leader' in gerr.lower():
+                consulerr = str(gerr)
+                if self.Err_string == consulerr:
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)

--- a/low-level/framework/utils/consulstore.py
+++ b/low-level/framework/utils/consulstore.py
@@ -45,7 +45,7 @@ class ConsulStore(Store):
             except Exception as gerr:
                 if 'no cluster leader' in gerr.lower():
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
-                        .format(connerr, retry_index))
+                        .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:
                     logger.warn("Error[{0}] consul error".format(gerr))
@@ -76,9 +76,14 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                logger.warn("Error[{0}] while writing data to consul {1}" \
-                    .format(gerr, key))
-                break
+                if 'no cluster leader' in gerr.lower():
+                    logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
+                        .format(gerr, retry_index))
+                    time.sleep(WAIT_BEFORE_RETRY)
+                else:
+                    logger.warn("Error[{0}] while writing data to consul {1}" \
+                        .format(gerr, key))
+                    break
 
     def _consul_get(self, key, **kwargs):
         """Load consul data from the given key."""
@@ -107,7 +112,7 @@ class ConsulStore(Store):
             except Exception as gerr:
                 if 'no cluster leader' in gerr.lower():
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
-                        .format(connerr, retry_index))
+                        .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:
                     logger.warn("Error[{0}] while reading data from consul {1}" \
@@ -149,7 +154,7 @@ class ConsulStore(Store):
             except Exception as gerr:
                 if 'no cluster leader' in gerr.lower():
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
-                        .format(connerr, retry_index))
+                        .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:
                     logger.warn("Error[{0}] while deleting key from consul {1}" \
@@ -177,7 +182,7 @@ class ConsulStore(Store):
             except Exception as gerr:
                 if 'no cluster leader' in gerr.lower():
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
-                        .format(connerr, retry_index))
+                        .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
                 else:
                     logger.warn("Error[{0}] while getting keys with given prefix {1}" \

--- a/low-level/framework/utils/consulstore.py
+++ b/low-level/framework/utils/consulstore.py
@@ -43,8 +43,13 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                logger.warn("Error[{0}] consul error".format(gerr))
-                break
+                if 'no cluster leader' in gerr.lower():
+                    logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
+                        .format(connerr, retry_index))
+                    time.sleep(WAIT_BEFORE_RETRY)
+                else:
+                    logger.warn("Error[{0}] consul error".format(gerr))
+                    break
 
     def _get_key(self, key):
         """remove '/' from begining of the key"""
@@ -142,9 +147,14 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                logger.warn("Error[{0}] while deleting key from consul {1}" \
-                    .format(gerr, key))
-                break
+                if 'no cluster leader' in gerr.lower():
+                    logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
+                        .format(connerr, retry_index))
+                    time.sleep(WAIT_BEFORE_RETRY)
+                else:
+                    logger.warn("Error[{0}] while deleting key from consul {1}" \
+                        .format(gerr, key))
+                    break
 
     def get_keys_with_prefix(self, prefix):
         """ get keys with given prefix
@@ -165,6 +175,11 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                logger.warn("Error[{0}] while getting keys with given prefix {1}" \
-                    .format(gerr, prefix))
-                break
+                if 'no cluster leader' in gerr.lower():
+                    logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
+                        .format(connerr, retry_index))
+                    time.sleep(WAIT_BEFORE_RETRY)
+                else:
+                    logger.warn("Error[{0}] while getting keys with given prefix {1}" \
+                        .format(gerr, prefix))
+                    break

--- a/low-level/framework/utils/consulstore.py
+++ b/low-level/framework/utils/consulstore.py
@@ -43,7 +43,7 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                if 'no cluster leader' in gerr.lower():
+                if 'No cluster leader' in gerr:
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -76,7 +76,7 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                if 'no cluster leader' in gerr.lower():
+                if 'No cluster leader' in gerr:
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -110,7 +110,7 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                if 'no cluster leader' in gerr.lower():
+                if 'No cluster leader' in gerr:
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -152,7 +152,7 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                if 'no cluster leader' in gerr.lower():
+                if 'No cluster leader' in gerr:
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -180,7 +180,7 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                if 'no cluster leader' in gerr.lower():
+                if 'No cluster leader' in gerr:
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)

--- a/low-level/framework/utils/consulstore.py
+++ b/low-level/framework/utils/consulstore.py
@@ -43,7 +43,8 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                if 'No cluster leader' in gerr:
+                gerr = str(gerr)
+                if 'no cluster leader' in gerr.lower():
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -76,7 +77,8 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                if 'No cluster leader' in gerr:
+                gerr = str(gerr)
+                if 'no cluster leader' in gerr.lower():
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -110,7 +112,8 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                if 'No cluster leader' in gerr:
+                gerr = str(gerr)
+                if 'no cluster leader' in gerr.lower():
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -152,7 +155,8 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                if 'No cluster leader' in gerr:
+                gerr = str(gerr)
+                if 'no cluster leader' in gerr.lower():
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -180,7 +184,8 @@ class ConsulStore(Store):
                 time.sleep(WAIT_BEFORE_RETRY)
 
             except Exception as gerr:
-                if 'No cluster leader' in gerr:
+                gerr = str(gerr)
+                if 'no cluster leader' in gerr.lower():
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)

--- a/low-level/framework/utils/consulstore.py
+++ b/low-level/framework/utils/consulstore.py
@@ -24,13 +24,11 @@ import consul
 from framework.utils.store import Store
 from framework.utils.service_logging import logger
 import pickle
-from framework.base.sspl_constants import MAX_CONSUL_RETRY, WAIT_BEFORE_RETRY
+from framework.base.sspl_constants import MAX_CONSUL_RETRY, WAIT_BEFORE_RETRY, CONSUL_ERR_STRING
 import time
 import requests
 
 class ConsulStore(Store):
-
-    Err_string = '500 No cluster leader'
 
     def __init__(self, host, port):
         super(Store, self).__init__()
@@ -46,7 +44,7 @@ class ConsulStore(Store):
 
             except Exception as gerr:
                 consuerr = str(gerr)
-                if self.Err_string == consuerr:
+                if CONSUL_ERR_STRING == consuerr:
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -80,7 +78,7 @@ class ConsulStore(Store):
 
             except Exception as gerr:
                 consulerr = str(gerr)
-                if self.Err_string == consulerr:
+                if CONSUL_ERR_STRING == consulerr:
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -115,7 +113,7 @@ class ConsulStore(Store):
 
             except Exception as gerr:
                 consulerr = str(gerr)
-                if self.Err_string == consulerr:
+                if CONSUL_ERR_STRING == consulerr:
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -158,7 +156,7 @@ class ConsulStore(Store):
 
             except Exception as gerr:
                 consulerr = str(gerr)
-                if self.Err_string == consulerr:
+                if CONSUL_ERR_STRING == consulerr:
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)
@@ -187,7 +185,7 @@ class ConsulStore(Store):
 
             except Exception as gerr:
                 consulerr = str(gerr)
-                if self.Err_string == consulerr:
+                if CONSUL_ERR_STRING == consulerr:
                     logger.warn("Error[{0}] consul connection refused Retry Index {1}" \
                         .format(gerr, retry_index))
                     time.sleep(WAIT_BEFORE_RETRY)

--- a/low-level/sensors/impl/generic/raid_integrity_data.py
+++ b/low-level/sensors/impl/generic/raid_integrity_data.py
@@ -265,7 +265,7 @@ class RAIDIntegritySensor(SensorThread, InternalMsgQ):
                     else:
                         raid_check += 1
                         time.sleep(WAIT_BEFORE_RETRY)
-        
+ 
             if raid_check > RaidDataConfig.MAX_RETRIES.value:
                     self._alert_resolved = False
                     self.alert_type = self.FAULT

--- a/sspl_test/rabbitmq/rabbitmq_ingress_processor_tests.py
+++ b/sspl_test/rabbitmq/rabbitmq_ingress_processor_tests.py
@@ -228,6 +228,13 @@ class RabbitMQingressProcessorTests(ScheduledModuleThread, InternalMsgQ):
             self._password = self._conf_reader._get_value_with_default(
                 self.RABBITMQPROCESSORTEST, self.PASSWORD, "sspl4ever"
             )
+            self.cluster_id = self._conf_reader._get_value_with_default(
+                self.SYSTEM_INFORMATION_KEY, self.CLUSTER_ID_KEY, '')
+
+            # Decrypt RabbitMQ Password
+            decryption_key = encryptor.gen_key(self.cluster_id, ServiceTypes.RABBITMQ.value)
+            self._password = encryptor.decrypt(decryption_key, self._password.encode('ascii'), "RabbitMQingressProcessor")
+
             self._connection = RabbitMQSafeConnection(
                 self._username,
                 self._password,
@@ -236,11 +243,6 @@ class RabbitMQingressProcessorTests(ScheduledModuleThread, InternalMsgQ):
                 self._routing_key,
                 self._queue_name
             )
-            self.cluster_id = self._conf_reader._get_value_with_default(
-                self.SYSTEM_INFORMATION_KEY, self.CLUSTER_ID_KEY, '')
-            # Decrypt RabbitMQ Password
-            decryption_key = encryptor.gen_key(self.cluster_id, ServiceTypes.RABBITMQ.value)
-            self._password = encryptor.decrypt(decryption_key, self._password.encode('ascii'), "RabbitMQingressProcessor")
         except Exception as ex:
             logger.exception("_configure_exchange: %r" % ex)
             raise


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    Add consul retry for the case when "No cluster leader" error is seen
  </code>
</pre>
## Problem Description
<pre>
  <code>
    SSPL performs retrying to consul only when there is a connection error. Hence, consul retry doesn't happen again. also, in  case of error other than connection, SSPL doesn not store the message to the consul and hence message gets lost.
  </code>
</pre>
## Solution
<pre>
  <code>
    Add retry in case if there is some Internal server error as well.
    Put the message in consul if there is any type of error happens while publishing the message to RabbitMQ Queue
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
    - [ ] No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Please describe the tests that you ran to verify your changes.
  </code>
</pre>
