### PR TITLE
EOS-14712:RAID Integrity Alerts seen recursively on all fresh deployed setups

### DIFF
--- a/low-level/framework/base/sspl_constants.py
+++ b/low-level/framework/base/sspl_constants.py
@@ -126,12 +126,12 @@ class RaidDataConfig(Enum):
     MISMATCH_COUNT_RESPONSE = '0'
     RAID_RESULT_DIR = "/tmp"
     RAID_RESULT_FILE_PATH = "/tmp/result_raid_health_file"
+    RAID_MISMATCH_FAULT_STATUS = "mismatch_cnt_fault_status"
     MAX_RETRIES = 10
     NEXT_ITERATION_TIME = 3600
     PRIORITY = 1
 
 class RaidAlertMsgs(Enum):
-    STATE_MSG = "'idle' state not found after max retries."
     MISMATCH_MSG = "MISMATCH COUNT is found, as count does not match to the default '0' value."
 
 


### PR DESCRIPTION
…d setups

## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    Multiple Alerts seen for RAIDIntegritySensor
  </code>
</pre>
## Problem Description
<pre>
  <code>
    RAID Integrity Alerts seen recursively on all fresh deployed setups
  </code>
</pre>
## Solution
<pre>
  <code>
    Done required changes in RAIDIntegritySensor
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
    - [ ] No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Please describe the tests that you ran to verify your changes.
  </code>
</pre>
