### PR TITLE
Remove hardcoding of RMQ credentials in SSPL test (#224)

### DIFF
--- a/sspl_test/framework/base/sspl_constants.py
+++ b/sspl_test/framework/base/sspl_constants.py
@@ -15,6 +15,8 @@
 # about this software or licensing, please email opensource@seagate.com or
 # cortx-questions@seagate.com.
 
+# TODO - Avoid duplicate code between sspl and sspl_test
+
 from enum import Enum
 
 PRODUCT_NAME = 'LDR_R1'
@@ -62,6 +64,8 @@ class StoreTypes(Enum):
     FILE = "file"
     CONSUL = "consul"
 
+class ServiceTypes(Enum):
+    RABBITMQ = "rabbitmq"
 
 if __name__ == "__main__":
     print(' '.join(enabled_products))

--- a/sspl_test/framework/utils/encryptor.py
+++ b/sspl_test/framework/utils/encryptor.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
+# about this software or licensing, please email opensource@seagate.com or
+# cortx-questions@seagate.com.
+
+
+#****************************************************************************
+# Description:       Common utility functions required for encryption purpose
+#****************************************************************************
+# TODO - Avoid duplicate code between sspl and sspl_test
+
+from cortx.utils.security.cipher import Cipher
+
+def gen_key(cluster_id, service_name):
+    # Generate key for decryption
+    key = Cipher.generate_key(cluster_id, service_name)
+    return key
+
+
+def encrypt(key, text):
+    """Encrypt sensitive data. Ex: RabbitMQ credentials."""
+    # Before encrypting text we need to convert string to bytes using encode()
+    # method
+    return Cipher.encrypt(key, text.encode())
+
+
+def decrypt(key, text, caller=None):
+    """Decrypt the <text>."""
+    decrypt_text = Cipher.decrypt(key, text).decode()
+    return decrypt_text

--- a/sspl_test/rabbitmq/rabbitmq_egress_processor.py
+++ b/sspl_test/rabbitmq/rabbitmq_egress_processor.py
@@ -26,6 +26,8 @@ import time
 from sspl_test.framework.base.module_thread import ScheduledModuleThread
 from sspl_test.framework.base.internal_msgQ import InternalMsgQ
 from sspl_test.framework.utils.service_logging import logger
+from sspl_test.framework.utils import encryptor
+from sspl_test.framework.base.sspl_constants import ServiceTypes
 from .rabbitmq_sspl_test_connector import RabbitMQSafeConnection
 
 import ctypes
@@ -213,12 +215,16 @@ class RabbitMQegressProcessor(ScheduledModuleThread, InternalMsgQ):
             self._site_id = self._conf_reader._get_value_with_default(
                 self.SYSTEM_INFORMATION, self.SITE_ID, '')
 
+            # Decrypt RabbitMQ Password
+            decryption_key = encryptor.gen_key(self._cluster_id, ServiceTypes.RABBITMQ.value)
+            self._password = encryptor.decrypt(decryption_key, self._password.encode('ascii'), "RabbitMQegressProcessor")
 
             if self._iem_route_addr != "":
                 logger.info("         Routing IEMs to host: %s" % self._iem_route_addr)
                 logger.info("         Using IEM exchange: %s" % self._iem_route_exchange_name)
         except Exception as ex:
             logger.exception("RabbitMQegressProcessor, _read_config: %r" % ex)
+            raise
 
     def _add_signature(self):
         """Adds the authentication signature to the message"""

--- a/sspl_test/rabbitmq/rabbitmq_ingress_processor_tests.py
+++ b/sspl_test/rabbitmq/rabbitmq_ingress_processor_tests.py
@@ -33,6 +33,8 @@ from sspl_test.framework.base.module_thread import ScheduledModuleThread
 from sspl_test.framework.base.internal_msgQ import InternalMsgQ
 from sspl_test.framework.utils.service_logging import logger
 from sspl_test.framework.base.sspl_constants import RESOURCE_PATH
+from sspl_test.framework.utils import encryptor
+from sspl_test.framework.base.sspl_constants import ServiceTypes
 from .rabbitmq_sspl_test_connector import RabbitMQSafeConnection
 import ctypes
 SSPL_SEC = ctypes.cdll.LoadLibrary('libsspl_sec.so.0')
@@ -53,6 +55,9 @@ class RabbitMQingressProcessorTests(ScheduledModuleThread, InternalMsgQ):
     VIRT_HOST             = 'virtual_host'
     USER_NAME             = 'username'
     PASSWORD              = 'password'
+
+    SYSTEM_INFORMATION_KEY = "SYSTEM_INFORMATION"
+    CLUSTER_ID_KEY = "cluster_id"
 
     JSON_ACTUATOR_SCHEMA = "SSPL-LL_Actuator_Response.json"
     JSON_SENSOR_SCHEMA   = "SSPL-LL_Sensor_Response.json"
@@ -223,6 +228,11 @@ class RabbitMQingressProcessorTests(ScheduledModuleThread, InternalMsgQ):
             self._password = self._conf_reader._get_value_with_default(
                 self.RABBITMQPROCESSORTEST, self.PASSWORD, "sspl4ever"
             )
+            self.cluster_id = self._conf_reader._get_value_with_default(
+                self.SYSTEM_INFORMATION_KEY, self.CLUSTER_ID_KEY, '')
+            # Decrypt RabbitMQ Password
+            decryption_key = encryptor.gen_key(self.cluster_id, ServiceTypes.RABBITMQ.value)
+            self._password = encryptor.decrypt(decryption_key, self._password.encode('ascii'), "RabbitMQingressProcessor")
             self._connection = RabbitMQSafeConnection(
                 self._username,
                 self._password,
@@ -233,6 +243,7 @@ class RabbitMQingressProcessorTests(ScheduledModuleThread, InternalMsgQ):
             )
         except Exception as ex:
             logger.exception("_configure_exchange: %r" % ex)
+            raise
 
     def shutdown(self):
         """Clean up scheduler queue and gracefully shutdown thread"""

--- a/sspl_test/run_qa_test.sh
+++ b/sspl_test/run_qa_test.sh
@@ -48,6 +48,12 @@ flask_help()
 
 pre_requisites()
 {
+    # copy RMQ password to sspl_test/config
+    pw=$($CONSUL_PATH/consul kv get sspl/config/RABBITMQINGRESSPROCESSOR/password)
+    $CONSUL_PATH/consul kv put sspl_test/config/RABBITMQINGRESSPROCESSORTESTS/password $pw
+    pw=$($CONSUL_PATH/consul kv get sspl/config/RABBITMQEGRESSPROCESSOR/password)
+    $CONSUL_PATH/consul kv put sspl_test/config/RABBITMQEGRESSPROCESSOR/password $pw
+
     if [ "$IS_VIRTUAL" == "true" ]
     then
         # Backing up original persistence data


### PR DESCRIPTION
Signed-off-by: Mohit Pathak <mohit.pathak@seagate.com>

## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    None
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Currently SSPL test uses hardcoded RMQ credentials
  </code>
</pre>
## Solution
<pre>
  <code>
    Made changes to read credentials from Consul
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
    - [ ] No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Please describe the tests that you ran to verify your changes.
  </code>
</pre>
