### PR TITLE
Changes for  EOS-14730 : 5U84 FW G280 - No controller alert observed on  GUI

### DIFF
--- a/low-level/framework/platforms/realstor/realstor_enclosure.py
+++ b/low-level/framework/platforms/realstor/realstor_enclosure.py
@@ -213,6 +213,7 @@ class RealStorEnclosure(StorageEnclosure):
         """Make webservice requests using common utils"""
         response = None
         retried_login = False
+        need_relogin = False
         tried_alt_ip = False
 
         while retry_count:

--- a/low-level/framework/platforms/realstor/realstor_enclosure.py
+++ b/low-level/framework/platforms/realstor/realstor_enclosure.py
@@ -251,7 +251,7 @@ class RealStorEnclosure(StorageEnclosure):
                     logger.error("%s returned mal-formed json:\n%s" % (url, badjson))
 
             # http 403 forbidden request, login & retry
-            if (response.status_code == self.ws.HTTP_FORBIDDEN or \
+            elif (response.status_code == self.ws.HTTP_FORBIDDEN or \
                 need_relogin) and retried_login is False:
                 logger.info("%s failed, retrying after login " % (url))
 

--- a/low-level/framework/platforms/realstor/realstor_enclosure.py
+++ b/low-level/framework/platforms/realstor/realstor_enclosure.py
@@ -206,7 +206,7 @@ class RealStorEnclosure(StorageEnclosure):
             self.active_wsport = self.mc1_wsport
 
         self.login()
-        logger.debug("CSDERR Current MC active ip {0}, active wsport {1}. Logged-in\
+        logger.debug("Current MC active ip {0}, active wsport {1}. Logged-in\
             ".format(self.active_ip, self.active_wsport))
 
     def ws_request(self, url, method, retry_count=MAX_RETRIES,
@@ -222,10 +222,6 @@ class RealStorEnclosure(StorageEnclosure):
                        self.common_reqheaders, post_data,
                        self.WEBSERVICE_TIMEOUT)
 
-            #TMP
-            logger.error("CSDERR {0} status code {1} headers {2}".format(url,\
-                response.status_code,response.headers))
-
             retry_count -= 1
 
             if response is None:
@@ -237,11 +233,8 @@ class RealStorEnclosure(StorageEnclosure):
 
                 try:
                     jresponse = json.loads(response.content)
-                    logger.error("CSDERR {0} -> {1}".format(url,jresponse))
 
                     if jresponse:
-
-                        logger.error("CSDERR {0} -> resp status {1}".format(url,jresponse['status']))
 
                         if jresponse['status'][0]['return-code'] == 2:
                             response_status = jresponse['status'][0]['response']
@@ -249,16 +242,16 @@ class RealStorEnclosure(StorageEnclosure):
                             # if call fails with invalid session key request
                             # seen in G280 fw version
                             if self.CLIAPI_RESP_INVSESSION in response_status:
-                               logger.error("CSDERR {0} need_relogin".format(url))
+                               logger.error("{0} need_relogin".format(url))
                                need_relogin = True
 
                 except ValueError as badjson:
-                    logger.error("CSDERR %s returned mal-formed json:\n%s" % (url, badjson))
+                    logger.error("%s returned mal-formed json:\n%s" % (url, badjson))
 
             # http 403 forbidden request, login & retry
             if (response.status_code == self.ws.HTTP_FORBIDDEN or \
                 need_relogin) and retried_login is False:
-                logger.info("CSDERR %s failed, retrying after login " % (url))
+                logger.info("%s failed, retrying after login " % (url))
 
                 self.login()
                 retried_login = True
@@ -295,8 +288,6 @@ class RealStorEnclosure(StorageEnclosure):
             logger.warn("Login webservice request failed {0}".format(url))
             return
 
-        logger.error("CSDERR %s response:\n%s" % (url, response))
-
         if response.status_code != self.ws.HTTP_OK:
             if response.status_code == self.ws.HTTP_TIMEOUT:
                 self.mc_timeout_counter += 1
@@ -310,7 +301,6 @@ class RealStorEnclosure(StorageEnclosure):
             logger.error("%s returned mal-formed json:\n%s" % (url, badjson))
 
         if jresponse:
-        logger.error("CSDERR %s jresponse:\n%s" % (url, jresponse))
 
             if jresponse['status'][0]['return-code'] == 1:
                 sessionKey = jresponse['status'][0]['response']

--- a/low-level/framework/platforms/realstor/realstor_enclosure.py
+++ b/low-level/framework/platforms/realstor/realstor_enclosure.py
@@ -242,7 +242,6 @@ class RealStorEnclosure(StorageEnclosure):
                             # if call fails with invalid session key request
                             # seen in G280 fw version
                             if self.CLIAPI_RESP_INVSESSION in response_status:
-                               logger.error("{0} need_relogin".format(url))
                                need_relogin = True
 
                 except ValueError as badjson:

--- a/low-level/framework/platforms/realstor/realstor_enclosure.py
+++ b/low-level/framework/platforms/realstor/realstor_enclosure.py
@@ -79,6 +79,7 @@ class RealStorEnclosure(StorageEnclosure):
 
     # CLI APIs Response status strings
     CLIAPI_RESP_INVSESSION = "Invalid sessionkey"
+    CLIAPI_RESP_FAILURE = 2
 
     # Realstor generic health states
     HEALTH_OK = "ok"
@@ -234,9 +235,11 @@ class RealStorEnclosure(StorageEnclosure):
                 try:
                     jresponse = json.loads(response.content)
 
+                    #TODO: Need a way to check return-code 2 in more optimal way if possible, 
+                    # currently being checked for all http 200 responses
                     if jresponse:
 
-                        if jresponse['status'][0]['return-code'] == 2:
+                        if jresponse['status'][0]['return-code'] == self.CLIAPI_RESP_FAILURE:
                             response_status = jresponse['status'][0]['response']
 
                             # if call fails with invalid session key request


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
   With FW G280 - No controller alert are observed on  GUI   
  </code>
</pre>
## Problem Description
<pre>
  <code>
    With FW G280 - No controller alert are observed on  GUI   
  </code>
</pre>
## Solution
<pre>
  <code>
   Added a fix to handle the error "Invalid sessionkey"  that comes in the HTTP rquest having the status HTTP_OK
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
   Testing will be done on hardware
  </code>
</pre>
