### PR TITLE
EOS-14904: Use 'utf-8' while converting signature to string

### DIFF
--- a/low-level/framework/rabbitmq/rabbitmq_egress_processor.py
+++ b/low-level/framework/rabbitmq/rabbitmq_egress_processor.py
@@ -238,7 +238,7 @@ class RabbitMQegressProcessor(ScheduledModuleThread, InternalMsgQ):
             SSPL_SEC.sspl_sign_message(msg_len, str(self._jsonMsg), self._signature_user,
                                        token, sig)
 
-            self._jsonMsg["signature"] = str(sig.raw)
+            self._jsonMsg["signature"] = str(sig.raw, encoding='utf-8')
         else:
             self._jsonMsg["signature"] = "SecurityLibNotInstalled"
 


### PR DESCRIPTION
calling str(sig.raw) without encoding calls __str__ method on object
which is returns printable representation of string ex. "'None'" and
converting this to json string escapes internal ' with \
ex. '"b\'None\'"'. This creates invalid json.
using encoding 'utf-8' while converting to str will solve the issue
as sig.raw returns bytes and bytes.decode() and str(bytes, encoding)
is equivalent.

Signed-off-by: Sandeep Anjara <sandeep.anjara@seagate.com>

## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    Please add Problem statement here...
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Please add Problem decription here...
  </code>
</pre>
## Solution
<pre>
  <code>
    Please add summary of the change,List any dependencies that are required for this change.
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
    - [ ] No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Please describe the tests that you ran to verify your changes.
  </code>
</pre>
