### PR TITLE
Add support for RabbitMQ 3.8.9 (#231)

### DIFF
--- a/low-level/files/opt/seagate/sspl/bin/sspl_config
+++ b/low-level/files/opt/seagate/sspl/bin/sspl_config
@@ -199,15 +199,64 @@ case $cmd in
         ;;
 esac
 
+# Get the version. Output can be 3.3.5 or 3.8.9 or in this format
+rabbitmq_version=$(rpm -qi rabbitmq-server | awk -F': ' '/Version/ {print $2}')
+
+# Get the Major release version parsed. (Eg: 3 from 3.8.9)
+rabbitmq_major_release=$(echo "${rabbitmq_version:0:-3}" | sed 's/.$//')
+
+# Get the Minor release version parsed. (Eg: 3.8 from 3.8.9)
+rabbitmq_minor_release=$(echo "${rabbitmq_version::-1}" | sed 's/.$//')
+
+# Get the Maitenance release version parsed from minor release. (Eg: 8 from 3.8)
+rabbitmq_maintenance_release=$(echo "${rabbitmq_minor_release:2:3}")
+
+get_cluster_running_nodes() {
+    pout=""
+    case $1 in
+
+    "rabbitmq" )
+        pout=$( get_rabbitmq_cluster_nodes )
+        echo "$pout"
+        ;;
+
+    * )
+        usage
+        ;;
+    esac
+
+}
+
+get_rabbitmq_cluster_nodes() {
+    if [ $rabbitmq_major_release -eq 3 ] && [ $rabbitmq_maintenance_release -eq 8 ];
+    then
+        rabbitmq_cluster_status=$(/usr/sbin/rabbitmqctl cluster_status --formatter json)
+        cluster_running_nodes=$(python3 -c "rabbitmq_status=$rabbitmq_cluster_status; print(rabbitmq_status['running_nodes'])")
+        pout=$(echo $cluster_running_nodes | sed 's/rabbit@//g' | cut -d '[' -f2 | cut -d ']' -f1 | tr -d \'\" | tr -d ' ')
+    elif [ $rabbitmq_version == "3.3.5" ];
+    then
+        out=$(rabbitmqctl cluster_status | grep running_nodes | cut -d '[' -f2 | cut -d ']' -f1 | sed 's/rabbit@//g' | sed 's/,/, /g')
+        pout=$(echo $out | sed  "s/'//g" | sed  "s/ //g")
+    else
+        echo "This RabbitMQ version: $rabbitmq_version is not supported"
+        exit 1
+    fi
+    echo "$pout"
+}
+
 # Skip this step if sspl is being configured for node replacement scenario as consul data is already
 # available on healthy node
 # Updating RabbitMQ cluster nodes.
 # In node replacement scenario, avoiding feeding again to avoid over writing already configured values
 # with which rabbitmq cluster may have been created
 [ -f $REPLACEMENT_NODE_ENV_VAR_FILE ] || {
+
+    message_broker="rabbitmq"
+
+    # Get the running nodes from a cluster
+    pout=$( get_cluster_running_nodes "$message_broker")
+
     # Update cluster_nodes key in consul
-    out=$(rabbitmqctl cluster_status | grep running_nodes | cut -d '[' -f2 | cut -d ']' -f1 | sed 's/rabbit@//g' | sed 's/,/, /g')
-    pout=$(echo $out | sed  "s/'//g" | sed  "s/ //g")
     $CONSUL_PATH/consul kv put sspl/config/RABBITMQCLUSTER/cluster_nodes $pout
     [ -n "$rmq_cluster_nodes" ] && $CONSUL_PATH/consul kv put sspl/config/RABBITMQCLUSTER/cluster_nodes $rmq_cluster_nodes
 }

--- a/low-level/framework/sspl_rabbitmq_reinit
+++ b/low-level/framework/sspl_rabbitmq_reinit
@@ -257,7 +257,7 @@ def _create_vhost_if_necessary(virtual_host, product):
             response = _send_command(command)
 
         vhosts = response.split('\n')
-        assert vhosts[0] == 'Listing vhosts ...'
+        print(f'vhosts: {vhosts}')
         for vhost in vhosts[1:-1]:
             if vhost == virtual_host:
                 return
@@ -270,9 +270,7 @@ def _create_vhost_if_necessary(virtual_host, product):
         vhosts = subprocess.check_output(
             [RABBITMQCTL, 'list_vhosts']
             ).decode("utf-8").split('\n')
-        assert vhosts[0] == 'Listing vhosts ...'
-        assert vhosts[-2] == '...done.'
-        assert vhosts[-1] == ''
+        print(f'vhosts: {vhosts}')
         for vhost in vhosts[1:-1]:
             if vhost == virtual_host:
                 return
@@ -324,7 +322,7 @@ def _create_user_if_necessary(username, password, virtual_host, product):
         response = _send_command(command)
 
         users = response.split("\n")
-        assert users[0] == 'Listing users ...'
+        print(f'Users: {users}')
         found_user = False
         for userspec in users[1:-1]:
             user = userspec.split()[0]
@@ -343,9 +341,7 @@ def _create_user_if_necessary(username, password, virtual_host, product):
         users = subprocess.check_output(
             [RABBITMQCTL, 'list_users']
             ).decode("utf-8").split('\n')
-        assert users[0] == 'Listing users ...'
-        assert users[-2] == '...done.'
-        assert users[-1] == ''
+        print('Users: {users}')
         found_user = False
         for userspec in users[1:-1]:
             user = userspec.split()[0]
@@ -446,8 +442,7 @@ def _send_command(command, fail_on_error=True):
     print(f'Executing: {command}')
     process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     response, error = process.communicate()
-    if error is not None and \
-       len(error) > 0:
+    if process.returncode != 0:
         print("command '%s' failed with error\n%s" % (command, error))
         if fail_on_error:
             sys.exit(1)


### PR DESCRIPTION
Signed-off-by: Madhura Mande <madhura.mande@seagate.com>

## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    Make SSPL compatible with latest RabbitMQ stable version  
</code>
</pre>
## Problem Description
<pre>
  <code>
        RabbitMQ configuration script was failing for RabbitMQ version 3.8.9. some assert statements were failing which was version specific. 
  </code>
</pre>
## Solution
<pre>
  <code>
   Remove assert statements which are specific to version.
   Make code independent of any version
 </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
    </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
   Its all tested with new RabbitMQ version on VM and HW
 </code>
</pre>
