### PR TITLE
EOS-15736 : Change License text in SSPL rpms

### DIFF
--- a/high-level/sspl_hl.spec
+++ b/high-level/sspl_hl.spec
@@ -34,7 +34,7 @@ Release:    %{_xyr_build_number}
 Summary:    Seagate System Platform Library - High Level
 
 Group:      Applications/System
-License:    Seagate Proprietary
+License:    Seagate
 URL:        %{_xyr_pkg_url}
 Source0:    %{_xyr_package_source}
 Vendor:     Seagate Technology LLC

--- a/libsspl_sec/libsspl_sec.spec
+++ b/libsspl_sec/libsspl_sec.spec
@@ -21,7 +21,7 @@ Version:    %{version}
 Release:    %{build_num}_git%{git_rev}%{?dist}
 Summary:    Segate System Platform Library - Security
 Group:      Libraries/System
-License:    Seagate Proprietary
+License:    Seagate
 URL:        https://github.com/Seagate/cortx-sspl
 Source0:    %{product_family}-sspl-%{version}.tgz
 Requires:   %{product_family}-sspl = %{version}-%{release}

--- a/low-level/cli/sspl_cli.spec
+++ b/low-level/cli/sspl_cli.spec
@@ -25,7 +25,7 @@ Release:	%{build_num}_git%{git_rev}%{?dist}
 Summary:	Installs sspl_ll_cli
 BuildArch:  noarch
 Group:		System Management
-License:	Seagate Proprietary
+License:	Seagate
 URL:		https://github.com/Seagate/cortx-sspl
 Source0:	%{name}-%{version}.tgz
 Requires:   %{product_family}-sspl = %{version}-%{release}

--- a/low-level/sspl-ll.spec
+++ b/low-level/sspl-ll.spec
@@ -27,7 +27,7 @@ Release:    %{build_num}_git%{git_rev}%{?dist}
 Summary:    Installs SSPL
 BuildArch:  noarch
 Group:      System Environment/Daemons
-License:    Seagate Proprietary
+License:    Seagate
 URL:        https://github.com/Seagate/cortx-sspl
 Source0:    %{name}-%{version}.tgz
 BuildRoot:  %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)

--- a/sspl_test/sspl-test.spec
+++ b/sspl_test/sspl-test.spec
@@ -25,7 +25,7 @@ Release:    %{build_num}_git%{git_rev}%{?dist}
 Summary:    Installs SSPL test for common test framework
 BuildArch:  noarch
 Group:      System Management
-License:    Seagate Proprietary
+License:    Seagate
 URL:        https://github.com/Seagate/cortx-sspl
 Source0:    %{name}-%{version}.tgz
 Requires:   %{product_family}-sspl = %{version}-%{release}

--- a/test/sspl-test.spec
+++ b/test/sspl-test.spec
@@ -22,7 +22,7 @@ Release:    %{build_num}_git%{git_rev}%{?dist}
 Summary:    Installs sspl-test scripts
 BuildArch:  noarch
 Group:      System Management
-License:    Seagate Proprietary
+License:    Seagate
 URL:        https://github.com/Seagate/cortx-sspl
 Source0:    %{name}-%{version}.tgz
 Requires:   sspl


### PR DESCRIPTION
Signed-off-by: Mohit Pathak <mohit.pathak@seagate.com>

## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    EOS-15736
  </code>
</pre>
## Problem Description
<pre>
  <code>
    RPM Validation result finds that the license value in cortx-sspl-test, cortx-sspl-cli and cortx-sspl rpms does not match with the expected value of "Seagate"
  </code>
</pre>
## Solution
<pre>
  <code>
    Changed the value in rpm spec files
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
    - [ ] No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Please describe the tests that you ran to verify your changes.
  </code>
</pre>
