### PR TITLE
EOS-15663: CSMui reports degraded condition on node health

### DIFF
--- a/low-level/files/opt/seagate/sspl/bin/generate_resource_health_view/resource_health_view
+++ b/low-level/files/opt/seagate/sspl/bin/generate_resource_health_view/resource_health_view
@@ -1049,6 +1049,10 @@ class SSPLHealthView(object):
         net_data = psutil.net_io_counters(pernic=True)
         # Array to hold data about each network interface
         for interface in net_data.keys():
+            # LDR R1 : Skip 'eno2' network interface monitoring as it is unused
+            # so no alerts should come for same
+            if interface.lower() == "eno2":
+                continue
             nw_cable_conn_status = self.fetch_nw_cable_conn_status(interface)
             network_cable_json.update({
                     NW_CABLE_RESOURCE_TYPE+'-'+interface:{

--- a/low-level/message_handlers/node_data_msg_handler.py
+++ b/low-level/message_handlers/node_data_msg_handler.py
@@ -327,7 +327,7 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
                 else:
                     self._log_debug("NodeDataMsgHandler, _process_msg " +
                             f"No past data found for {self.sensor_type} sensor type")
-            
+
             elif self.sensor_type == "raid_integrity":
                 self._generate_raid_integrity_data(jsonMsg)
                 sensor_message_type = self.os_sensor_type.get(self.sensor_type, "")
@@ -670,6 +670,9 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
         try:
             for interface in interfaces:
                 interface_name = interface.get("ifId")
+                # LDR R1 : Skip 'eno2' network interface monitoring as it is unused, so no alerts should come for same
+                if interface_name.lower() == "eno2":
+                    continue
                 nw_status = interface.get("nwStatus")
                 logger.debug("{0}:{1}".format(interface_name, nw_status))
                 # fault detected (Down/UNKNOWN, Up/UNKNOWN to Down, Up/Down to UNKNOWN)
@@ -705,6 +708,10 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
 
             interface_name = interface.get("ifId")
             phy_link_status = interface.get("nwCableConnStatus")
+
+            # LDR R1 : Skip 'eno2' network interface monitoring as it is unused, so no alerts should come for same
+            if interface_name.lower() == "eno2":
+                continue
 
             # fault detected (Down, Up to Down)
             if phy_link_status == 'DOWN':
@@ -879,7 +886,7 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
             jsonMsg = RAIDintegrityMsg.getJson()
             self.raid_integrity_data = jsonMsg
             self.os_sensor_type["raid_integrity"] = self.raid_integrity_data
-             
+
             self._log_debug("_generate_raid_integrity_data, host_id: %s" %
                     (self._node_sensor.host_id))
 


### PR DESCRIPTION
Signed-off-by: Mohit Pathak <mohit.pathak@seagate.com>

## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    EOS-16553
  </code>
</pre>
## Problem Description
<pre>
  <code>
    CSMui shows degraded state due to eno2 alert
  </code>
</pre>
## Solution
<pre>
  <code>
    Disable monitoring for eno2 interface
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
    - [ ] No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Please describe the tests that you ran to verify your changes.
  </code>
</pre>
