### PR TITLE
EOS-15983: Automate code coverage

### DIFF
--- a/low-level/framework/sspl_ll_d
+++ b/low-level/framework/sspl_ll_d
@@ -74,7 +74,7 @@ from message_handlers.real_stor_actuator_msg_handler import RealStorActuatorMsgH
 # Message to send to HAlon upon critical thread errors
 from json_msgs.messages.actuators.thread_controller import ThreadControllerMsg
 
-# Creating Coverage instance for coverage report generation
+#DO NOT EDIT: Marker comment to dynamically add code to initialize coverage obj for code coverage report generation
 
 # Section and key in config file for bootstrap
 SSPL_SETTING    = 'SSPL-LL_SETTING'
@@ -723,7 +723,7 @@ def set_log_level(signal_number, frame):
         log_level = log_level.decode('utf-8')
     logger.info(f"Received SIGUSR1 signal to set log level to '{log_level}'")
     logger.setLevel(log_level)
-    # Coverage report commands to stop, save and generate coverage report
+    #DO NOT EDIT: Marker comment to dynamically add code to stop coverage, save and generate code coverage report
 
 
 def refresh_iem_log_file(signal_number, frame):
@@ -806,7 +806,7 @@ if __name__ == "__main__":
             with open(pidfile, "w") as fileObj:
                 fileObj.write(str(os.getpid()))
 
-        #Staring coverage report scope
+        #DO NOT EDIT: Marker comment to dynamically add code to start the code coverage scope
 
         # Start sspl-ll as a main process running multiple threads
         main(conf_reader, systemd_support)

--- a/low-level/framework/sspl_ll_d
+++ b/low-level/framework/sspl_ll_d
@@ -74,6 +74,7 @@ from message_handlers.real_stor_actuator_msg_handler import RealStorActuatorMsgH
 # Message to send to HAlon upon critical thread errors
 from json_msgs.messages.actuators.thread_controller import ThreadControllerMsg
 
+# Creating Coverage instance for coverage report generation
 
 # Section and key in config file for bootstrap
 SSPL_SETTING    = 'SSPL-LL_SETTING'
@@ -722,6 +723,7 @@ def set_log_level(signal_number, frame):
         log_level = log_level.decode('utf-8')
     logger.info(f"Received SIGUSR1 signal to set log level to '{log_level}'")
     logger.setLevel(log_level)
+    # Coverage report commands to stop, save and generate coverage report
 
 
 def refresh_iem_log_file(signal_number, frame):
@@ -803,6 +805,8 @@ if __name__ == "__main__":
 
             with open(pidfile, "w") as fileObj:
                 fileObj.write(str(os.getpid()))
+
+        #Staring coverage report scope
 
         # Start sspl-ll as a main process running multiple threads
         main(conf_reader, systemd_support)

--- a/sspl_test/coverage/coverage_code
+++ b/sspl_test/coverage/coverage_code
@@ -1,22 +1,22 @@
 from coverage import Coverage
 co = Coverage(
- 			data_file='/tmp/sspl/.sspl_report',
- 			include="/opt/seagate/*",
- 			omit=['*/.local/*', '*/usr/*'],
- 			# config_file='/tmp/sspl/.coveragerc',
+            data_file='/tmp/sspl/.sspl_report',
+            include="/opt/seagate/*",
+            omit=['*/.local/*', '*/usr/*'],
+            # config_file='/tmp/sspl/.coveragerc',
  			)
         logger.info("Starting coverage report scope")
- 		co.start()
- 	logger.info("Ending Coverage Scope")
- 	co.stop()
- 	logger.info("coverage object stopped.")
- 	co.save()
- 	logger.info("coverage info saved.")
- 	cov_per = co.xml_report(
+        co.start()
+    logger.info("Ending Coverage Scope")
+    co.stop()
+    logger.info("coverage object stopped.")
+    co.save()
+    logger.info("coverage info saved.")
+    cov_per = co.xml_report(
  						outfile='/tmp/sspl/sspl_xml_coverage_report.xml',
  						ignore_errors=True,
  					)
- 	logger.info(f"XML coverage report generated with coverage of {cov_per}%")
+    logger.info(f"XML coverage report generated with coverage of {cov_per}%")
  	## Enable below code to inable HTML report generation
  	# html_cov_per = co.html_report(
  	#                     directory='/tmp/sspl/sspl_html_coverage',

--- a/sspl_test/coverage/coverage_code
+++ b/sspl_test/coverage/coverage_code
@@ -1,0 +1,25 @@
+from coverage import Coverage
+co = Coverage(
+ 			data_file='/tmp/sspl/.sspl_report',
+ 			include="/opt/seagate/*",
+ 			omit=['*/.local/*', '*/usr/*'],
+ 			# config_file='/tmp/sspl/.coveragerc',
+ 			)
+        logger.info("Starting coverage report scope")
+ 		co.start()
+ 	logger.info("Ending Coverage Scope")
+ 	co.stop()
+ 	logger.info("coverage object stopped.")
+ 	co.save()
+ 	logger.info("coverage info saved.")
+ 	cov_per = co.xml_report(
+ 						outfile='/tmp/sspl/sspl_xml_coverage_report.xml',
+ 						ignore_errors=True,
+ 					)
+ 	logger.info(f"XML coverage report generated with coverage of {cov_per}%")
+ 	## Enable below code to inable HTML report generation
+ 	# html_cov_per = co.html_report(
+ 	#                     directory='/tmp/sspl/sspl_html_coverage',
+ 	#                     ignore_errors=True,
+ 	#                 )
+ 	# logger.info(f"HTML coverage report geverated with coverage of {html_cov_per}%")

--- a/sspl_test/coverage/start_sspl_coverage.sh
+++ b/sspl_test/coverage/start_sspl_coverage.sh
@@ -1,0 +1,55 @@
+#! /bin/sh
+
+echo "Stoping sspl-ll.service for setting up coverage"
+systemctl stop sspl-ll.service
+
+echo "Checking and installing coverage.py"
+pip3_status=$(which pip3)
+pip_status=$(which pip)
+if [[ $pip3_status =~ "/bin/pip3" ]]
+then 
+    pip3 install coverage
+elif [[$pip_status =~ "/bin/pip"]]
+then
+    pip install coverage
+fi
+
+echo "Creating required files for coverage.."
+iofdir='/opt/seagate/cortx/sspl/low-level/framework'
+# iofdir='/opt/sumedh/withoutpyi/cortx-sspl/low-level/framework'
+usdir='/opt/seagate/cortx/sspl/sspl_test/coverage'
+# usdir='/opt/sumedh/withoutpyi/cortx-sspl/sspl_test/coverage'
+
+sudo cp $iofdir/sspl_ll_d $iofdir/sspl_ll_d_coverage
+
+copy_lines() {
+    for line_num in `seq $1 $2` 
+    do 
+        str=`sed $((line_num))!d $usdir/coverage_code`; fix='\';
+        str="${fix}${str}";
+        curr_line=$((curr_line+1));
+        echo $curr_line $str;
+        sed -i "$curr_line i $str" $iofdir/sspl_ll_d_coverage;
+    done    
+}
+
+curr_line=`grep -n "# Creating Coverage instance for coverage report generation" $iofdir/sspl_ll_d_coverage | cut -d : -f1`
+copy_lines 1 7
+
+curr_line=`grep -n "#Staring coverage report scope" $iofdir/sspl_ll_d_coverage | cut -d : -f1`
+copy_lines 8 9
+
+curr_line=`grep -n "# Coverage report commands to stop, save and generate coverage report" $iofdir/sspl_ll_d_coverage | cut -d : -f1`
+copy_lines 10 25
+
+echo "Changing the soft link and adding permission for /tmp/sspl/ folder"
+ln -sf $iofdir/sspl_ll_d_coverage /usr/bin/sspl_ll_d
+
+chmod 777 /tmp/sspl/* 
+chown sspl-ll:sspl-ll /tmp/sspl/ -R
+
+echo "Staring the sspl-ll.service back.."
+systemctl start sspl-ll.service
+
+echo "Environment is set for testing.. "
+echo "Please execute stop_sspl_coverage.sh after testing so that coverage report is generated."

--- a/sspl_test/coverage/start_sspl_coverage.sh
+++ b/sspl_test/coverage/start_sspl_coverage.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-echo "Stoping sspl-ll.service for setting up coverage"
+echo "Stoping sspl-ll.service for enabling code coverage"
 systemctl stop sspl-ll.service
 
 echo "Checking and installing coverage.py"
@@ -15,35 +15,33 @@ then
 fi
 
 echo "Creating required files for coverage.."
-iofdir='/opt/seagate/cortx/sspl/low-level/framework'
-# iofdir='/opt/sumedh/withoutpyi/cortx-sspl/low-level/framework'
-usdir='/opt/seagate/cortx/sspl/sspl_test/coverage'
-# usdir='/opt/sumedh/withoutpyi/cortx-sspl/sspl_test/coverage'
+target_dir='/opt/seagate/cortx/sspl/low-level/framework'
+cov_code_dir='/opt/seagate/cortx/sspl/sspl_test/coverage'
 
-sudo cp $iofdir/sspl_ll_d $iofdir/sspl_ll_d_coverage
+sudo cp $target_dir/sspl_ll_d $target_dir/sspl_ll_d_coverage
 
 copy_lines() {
     for line_num in `seq $1 $2` 
     do 
-        str=`sed $((line_num))!d $usdir/coverage_code`; fix='\';
+        str=`sed $((line_num))!d $cov_code_dir/coverage_code`; fix='\';
         str="${fix}${str}";
         curr_line=$((curr_line+1));
         echo $curr_line $str;
-        sed -i "$curr_line i $str" $iofdir/sspl_ll_d_coverage;
+        sed -i "$curr_line i $str" $target_dir/sspl_ll_d_coverage;
     done    
 }
 
-curr_line=`grep -n "# Creating Coverage instance for coverage report generation" $iofdir/sspl_ll_d_coverage | cut -d : -f1`
+curr_line=`grep -n "#DO NOT EDIT: Marker comment to dynamically add code to initialize coverage obj for code coverage report generation" $target_dir/sspl_ll_d_coverage | cut -d : -f1`
 copy_lines 1 7
 
-curr_line=`grep -n "#Staring coverage report scope" $iofdir/sspl_ll_d_coverage | cut -d : -f1`
+curr_line=`grep -n "#DO NOT EDIT: Marker comment to dynamically add code to start the code coverage scope" $target_dir/sspl_ll_d_coverage | cut -d : -f1`
 copy_lines 8 9
 
-curr_line=`grep -n "# Coverage report commands to stop, save and generate coverage report" $iofdir/sspl_ll_d_coverage | cut -d : -f1`
+curr_line=`grep -n "#DO NOT EDIT: Marker comment to dynamically add code to stop coverage, save and generate code coverage report" $target_dir/sspl_ll_d_coverage | cut -d : -f1`
 copy_lines 10 25
 
 echo "Changing the soft link and adding permission for /tmp/sspl/ folder"
-ln -sf $iofdir/sspl_ll_d_coverage /usr/bin/sspl_ll_d
+ln -sf $target_dir/sspl_ll_d_coverage /usr/bin/sspl_ll_d
 
 chmod 777 /tmp/sspl/* 
 chown sspl-ll:sspl-ll /tmp/sspl/ -R

--- a/sspl_test/coverage/start_sspl_coverage.sh
+++ b/sspl_test/coverage/start_sspl_coverage.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-echo "Stoping sspl-ll.service for enabling code coverage"
+echo "Stopping sspl-ll.service for enabling code coverage"
 systemctl stop sspl-ll.service
 
 echo "Checking and installing coverage.py"
@@ -46,7 +46,7 @@ ln -sf $target_dir/sspl_ll_d_coverage /usr/bin/sspl_ll_d
 chmod 777 /tmp/sspl/* 
 chown sspl-ll:sspl-ll /tmp/sspl/ -R
 
-echo "Staring the sspl-ll.service back.."
+echo "Starting the sspl-ll.service back.."
 systemctl start sspl-ll.service
 
 echo "Environment is set for testing.. "

--- a/sspl_test/coverage/stop_sspl_coverage.sh
+++ b/sspl_test/coverage/stop_sspl_coverage.sh
@@ -3,8 +3,9 @@
 target_dir='/opt/seagate/cortx/sspl/low-level/framework'
 
 echo "Generating the coverage report.."
-consul kv put sspl/config/SYSTEM_INFORMATION/log_level DEBUG
-sleep 30s
+pid=$(ps aux | grep "sspl-ll.*sspl_ll_d" | awk '{print$2}' | awk 'NR==1')
+kill -10 $pid
+sleep 20s
 timestamp=$(stat /tmp/sspl/sspl_xml_coverage_report.xml | grep Modify | cut -d ' ' -f2,3)
 echo "${timestamp} : The report is saved at /tmp/sspl/sspl_xml_coverage_report.xml"
 
@@ -14,8 +15,6 @@ systemctl stop sspl-ll.service
 ln -sf $target_dir/sspl_ll_d /usr/bin/sspl_ll_d
 
 sudo rm $target_dir/sspl_ll_d_coverage
-
-consul kv put sspl/config/SYSTEM_INFORMATION/log_level INFO
 
 echo "Normal sspl environment is set staring the sspl-ll.service"
 systemctl start sspl-ll.service

--- a/sspl_test/coverage/stop_sspl_coverage.sh
+++ b/sspl_test/coverage/stop_sspl_coverage.sh
@@ -1,19 +1,19 @@
 #! /bin/sh
 
-# iofdir='/opt/sumedh/withoutpyi/cortx-sspl/low-level/framework'
-iofdir='/opt/seagate/cortx/sspl/low-level/framework'
+target_dir='/opt/seagate/cortx/sspl/low-level/framework'
 
 echo "Generating the coverage report.."
 consul kv put sspl/config/SYSTEM_INFORMATION/log_level DEBUG
 sleep 30s
-echo "The report is saved at /tmp/sspl/sspl_xml_coverage_report.xml"
+timestamp=`stat /tmp/sspl/sspl_xml_coverage_report.xml | grep Modify | cut -d ' ' -f2,3`
+echo "${timestamp} : The report is saved at /tmp/sspl/sspl_xml_coverage_report.xml"
 
 echo "Stoping sspl-ll for resetting the sspl environment"
 systemctl stop sspl-ll.service
 
-ln -sf $iofdir/sspl_ll_d /usr/bin/sspl_ll_d
+ln -sf $target_dir/sspl_ll_d /usr/bin/sspl_ll_d
 
-sudo rm $iofdir/sspl_ll_d_coverage
+sudo rm $target_dir/sspl_ll_d_coverage
 
 consul kv put sspl/config/SYSTEM_INFORMATION/log_level INFO
 

--- a/sspl_test/coverage/stop_sspl_coverage.sh
+++ b/sspl_test/coverage/stop_sspl_coverage.sh
@@ -4,7 +4,7 @@ target_dir='/opt/seagate/cortx/sspl/low-level/framework'
 
 echo "Generating the coverage report.."
 pid=$(ps aux | grep "sspl-ll.*sspl_ll_d" | awk '{print$2}' | awk 'NR==1')
-kill -10 $pid
+kill -10 "$pid"
 sleep 20s
 timestamp=$(stat /tmp/sspl/sspl_xml_coverage_report.xml | grep Modify | cut -d ' ' -f2,3)
 echo "${timestamp} : The report is saved at /tmp/sspl/sspl_xml_coverage_report.xml"

--- a/sspl_test/coverage/stop_sspl_coverage.sh
+++ b/sspl_test/coverage/stop_sspl_coverage.sh
@@ -5,7 +5,7 @@ target_dir='/opt/seagate/cortx/sspl/low-level/framework'
 echo "Generating the coverage report.."
 consul kv put sspl/config/SYSTEM_INFORMATION/log_level DEBUG
 sleep 30s
-timestamp=`stat /tmp/sspl/sspl_xml_coverage_report.xml | grep Modify | cut -d ' ' -f2,3`
+timestamp=$(stat /tmp/sspl/sspl_xml_coverage_report.xml | grep Modify | cut -d ' ' -f2,3)
 echo "${timestamp} : The report is saved at /tmp/sspl/sspl_xml_coverage_report.xml"
 
 echo "Stoping sspl-ll for resetting the sspl environment"

--- a/sspl_test/coverage/stop_sspl_coverage.sh
+++ b/sspl_test/coverage/stop_sspl_coverage.sh
@@ -5,7 +5,7 @@ iofdir='/opt/seagate/cortx/sspl/low-level/framework'
 
 echo "Generating the coverage report.."
 consul kv put sspl/config/SYSTEM_INFORMATION/log_level DEBUG
-
+sleep 30s
 echo "The report is saved at /tmp/sspl/sspl_xml_coverage_report.xml"
 
 echo "Stoping sspl-ll for resetting the sspl environment"

--- a/sspl_test/coverage/stop_sspl_coverage.sh
+++ b/sspl_test/coverage/stop_sspl_coverage.sh
@@ -1,0 +1,22 @@
+#! /bin/sh
+
+# iofdir='/opt/sumedh/withoutpyi/cortx-sspl/low-level/framework'
+iofdir='/opt/seagate/cortx/sspl/low-level/framework'
+
+echo "Generating the coverage report.."
+consul kv put sspl/config/SYSTEM_INFORMATION/log_level DEBUG
+
+echo "The report is saved at /tmp/sspl/sspl_xml_coverage_report.xml"
+
+echo "Stoping sspl-ll for resetting the sspl environment"
+systemctl stop sspl-ll.service
+
+ln -sf $iofdir/sspl_ll_d /usr/bin/sspl_ll_d
+
+sudo rm $iofdir/sspl_ll_d_coverage
+
+consul kv put sspl/config/SYSTEM_INFORMATION/log_level INFO
+
+echo "Normal sspl environment is set staring the sspl-ll.service"
+systemctl start sspl-ll.service
+echo "Done."


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
    To automate the SSPL code Coverage report generation
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Write scripts for automation of coverage report generation
  </code>
</pre>
## Solution
<pre>
  <code>
    Added 3 files at  cortx-monitor/sspl_test/coverage and added comments in sspl_ll_d file
    1st file => coverage_code : this file has the code snippet that needs to be inserted into sspl_ll_d for enabling 
                                   coverage generation
    2nd file => start_sspl_coverage.sh : this is the script file which sets up the environment for coverage report 
                                   generation. After executing this script we can perform all the necessary tests for sspl, it 
                                   will trace all the files during testing.
     3rd file => stop_sspl_coverage.sh : After successful execution of tests on sspl, this script should be run to 
                                   generate the coverage report and to clean and reset the environment back to normal.
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ * ] Yes
    - [ ] No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    **Tested the execution of scripts, and it successfully generated the results without any effect on sspl or sanity.**
    
**1. start_sspl_coverage :** 
[root@ssc-vm-1546 cortx-sspl]# /opt/seagate/cortx/sspl/sspl_test/coverage/start_sspl_coverage.sh
Stoping sspl-ll.service for setting up coverage
Checking and installing coverage.py
which: no pip in (/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin)
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Requirement already satisfied: coverage in /usr/local/lib64/python3.6/site-packages
Creating required files for coverage..
78 \from coverage import Coverage
79 \co = Coverage(
80 \ data_file='/tmp/sspl/.sspl_report',
81 \ include="/opt/seagate/*",
82 \ omit=['*/.local/*', '*/usr/*'],
83 \ # config_file='/tmp/sspl/.coveragerc',
84 \ )
817 \ logger.info("Starting coverage report scope")
818 \ co.start()
734 \ logger.info("Ending Coverage Scope")
735 \ co.stop()
736 \ logger.info("coverage object stopped.")
737 \ co.save()
738 \ logger.info("coverage info saved.")
739 \ cov_per = co.xml_report(
740 \ outfile='/tmp/sspl/sspl_xml_coverage_report.xml',
741 \ ignore_errors=True,
742 \ )
743 \ logger.info(f"XML coverage report generated with coverage of {cov_per}%")
744 \ ## Enable below code to inable HTML report generation
745 \ # html_cov_per = co.html_report(
746 \ # directory='/tmp/sspl/sspl_html_coverage',
747 \ # ignore_errors=True,
748 \ # )
749 \ # logger.info(f"HTML coverage report geverated with coverage of {html_cov_per}%")
Changing the soft link and adding permission for /tmp/sspl/ folder
Staring the sspl-ll.service back..
Environment is set for testing..
Please execute stop_sspl_coverage.sh after testing so that coverage report is generated.

**2. Execution of tests :** 
     ******************************************************************************************
TestSuite                                                    Status     Duration(secs)
******************************************************************************************
alerts.node.test_node_disk_actuator                          Skip                0s
alerts.os.test_disk_space_alert                              Pass                4s
alerts.os.test_node_cpu_data_sensor                          Pass               10s
alerts.os.test_node_raid_integrity_sensor                    Pass                0s
alerts.os.test_node_host_data_sensor                         Fail                0s
alerts.os.test_node_if_data_sensor                           Pass               13s
alerts.realstor.test_real_stor_controller_sensor             Pass                4s
alerts.realstor.test_real_stor_disk_sensor                   Pass                4s
alerts.realstor.test_real_stor_fan_sensor                    Pass                4s
alerts.realstor.test_real_stor_fan_actuator                  Pass                4s
alerts.realstor.test_real_stor_psu_sensor                    Pass                4s
alerts.realstor.test_real_stor_for_platform_sensor           Pass                6s
alerts.realstor.test_real_stor_sideplane_expander_sensor     Pass                4s
alerts.realstor.test_real_stor_disk_actuator                 Pass                4s
alerts.realstor.test_real_stor_psu_actuator                  Pass                4s
alerts.realstor.test_real_stor_controller_actuator           Pass                6s
alerts.realstor.test_real_stor_sideplane_actuator            Pass                4s
alerts.node.test_node_psu_actuator                           Skip                0s
alerts.node.test_node_fan_actuator                           Skip                0s
alerts.realstor.test_real_stor_enclosure_sensor              Pass              141s

****************************************************
TestSuite:20 Tests:19 Passed:18 Failed:1 Skipped:3 TimeTaken:240s
******************************************************
**3. stop_sspl_coverage.sh :** 
[root@ssc-vm-1546 cortx-sspl]#  /opt/seagate/cortx/sspl/sspl_test/coverage/stop_sspl_coverage.sh
Generating the coverage report..
Success! Data written to: sspl/config/SYSTEM_INFORMATION/log_level
The report is saved at /tmp/sspl/sspl_xml_coverage_report.xml
Stoping sspl-ll for resetting the sspl environment
Success! Data written to: sspl/config/SYSTEM_INFORMATION/log_level
Normal sspl environment is set staring the sspl-ll.service
Done.
  </code>
</pre>
