### PR TITLE
Improvement for node data alerts(cpu_usage, disk-space ,memeory_usage).

### DIFF
--- a/low-level/json_msgs/messages/sensors/cpu_data.py
+++ b/low-level/json_msgs/messages/sensors/cpu_data.py
@@ -39,7 +39,7 @@ class CPUdataMsg(BaseSensorMsg):
     MESSAGE_VERSION  = "1.0.0"
 
     SEVERITY = "warning"
-    RESOURCE_TYPE = "node:os:cpu"
+    RESOURCE_TYPE = "node:os:cpu_usage"
     RESOURCE_ID = "0"
 
     def __init__(self, host_id,
@@ -60,6 +60,7 @@ class CPUdataMsg(BaseSensorMsg):
                        node_id,
                        cluster_id,
                        alert_type,
+                       event,
                        username  = "SSPL-LL",
                        signature = "N/A",
                        in_time      = "N/A",
@@ -88,6 +89,7 @@ class CPUdataMsg(BaseSensorMsg):
         self._node_id           = node_id
         self._cluster_id        = cluster_id
         self.alert_type         = alert_type
+        self.event              = event
 
         epoch_time = str(int(time.time()))
         alert_id = mon_utils.get_alert_id(epoch_time)
@@ -132,7 +134,8 @@ class CPUdataMsg(BaseSensorMsg):
                                   "systemTime"    : self._system_time,
                                   "userTime"      : self._user_time,
                                   "coreData"      : self._core_data,
-                                  "cpu_usage"     : self._cpu_usage
+                                  "cpu_usage"     : self._cpu_usage,
+                                  "event"         : self.event
                               }
                           }
                       }

--- a/low-level/json_msgs/messages/sensors/cpu_data.py
+++ b/low-level/json_msgs/messages/sensors/cpu_data.py
@@ -91,6 +91,9 @@ class CPUdataMsg(BaseSensorMsg):
         self.alert_type         = alert_type
         self.event              = event
 
+        if self.alert_type == "fault_resolved":
+            self.SEVERITY = "informational"
+
         epoch_time = str(int(time.time()))
         alert_id = mon_utils.get_alert_id(epoch_time)
 
@@ -120,7 +123,8 @@ class CPUdataMsg(BaseSensorMsg):
                                 "cluster_id": self._cluster_id,
                                 "resource_type": self.RESOURCE_TYPE,
                                 "resource_id": self.RESOURCE_ID,
-                                "event_time": epoch_time
+                                "event_time": epoch_time,
+                                "description": self.event
                               },
                           "specific_info": {
                                   "localtime"     : self._local_time,
@@ -134,8 +138,7 @@ class CPUdataMsg(BaseSensorMsg):
                                   "systemTime"    : self._system_time,
                                   "userTime"      : self._user_time,
                                   "coreData"      : self._core_data,
-                                  "cpu_usage"     : self._cpu_usage,
-                                  "event"         : self.event
+                                  "cpu_usage"     : self._cpu_usage
                               }
                           }
                       }

--- a/low-level/json_msgs/messages/sensors/disk_space_alert.py
+++ b/low-level/json_msgs/messages/sensors/disk_space_alert.py
@@ -77,6 +77,9 @@ class DiskSpaceAlertMsg(BaseSensorMsg):
         self.alert_type              = alert_type
         self.event                   = event
 
+        if self.alert_type == "fault_resolved":
+            self.SEVERITY = "informational"
+
         epoch_time = str(calendar.timegm(time.gmtime()))
         alert_id = mon_utils.get_alert_id(epoch_time)
 
@@ -106,7 +109,8 @@ class DiskSpaceAlertMsg(BaseSensorMsg):
                                 "cluster_id": self._cluster_id,
                                 "resource_type": self.RESOURCE_TYPE,
                                 "resource_id": self.RESOURCE_ID,
-                                "event_time": epoch_time
+                                "event_time": epoch_time,
+                                "description": self.event
                               },
                               "specific_info": {
                                   "freeSpace"  : {
@@ -117,8 +121,7 @@ class DiskSpaceAlertMsg(BaseSensorMsg):
                                       "value" : self._total_space,
                                       "units" : self._units
                                   },
-                                  "diskUsedPercentage" : self._disk_used_percentage,
-                                  "event" : self.event
+                                  "diskUsedPercentage" : self._disk_used_percentage
                               }
                           }
                       }

--- a/low-level/json_msgs/messages/sensors/disk_space_alert.py
+++ b/low-level/json_msgs/messages/sensors/disk_space_alert.py
@@ -51,6 +51,7 @@ class DiskSpaceAlertMsg(BaseSensorMsg):
                        site_id, rack_id,
                        node_id, cluster_id,
                        alert_type,
+                       event,
                        username  = "SSPL-LL",
                        signature = "N/A",
                        in_time      = "N/A",
@@ -74,6 +75,7 @@ class DiskSpaceAlertMsg(BaseSensorMsg):
         self._node_id                = node_id
         self._cluster_id             = cluster_id
         self.alert_type              = alert_type
+        self.event                   = event
 
         epoch_time = str(calendar.timegm(time.gmtime()))
         alert_id = mon_utils.get_alert_id(epoch_time)
@@ -115,7 +117,8 @@ class DiskSpaceAlertMsg(BaseSensorMsg):
                                       "value" : self._total_space,
                                       "units" : self._units
                                   },
-                                  "diskUsedPercentage" : self._disk_used_percentage
+                                  "diskUsedPercentage" : self._disk_used_percentage,
+                                  "event" : self.event
                               }
                           }
                       }

--- a/low-level/json_msgs/messages/sensors/host_update.py
+++ b/low-level/json_msgs/messages/sensors/host_update.py
@@ -85,6 +85,9 @@ class HostUpdateMsg(BaseSensorMsg):
         self.alert_type         = alert_type
         self.event              = event
 
+        if self.alert_type == "fault_resolved":
+            self.SEVERITY = "informational"
+
         epoch_time = str(int(time.time()))
         alert_id = mon_utils.get_alert_id(epoch_time)
 
@@ -114,7 +117,8 @@ class HostUpdateMsg(BaseSensorMsg):
                                 "cluster_id": self._cluster_id,
                                 "resource_type": self.RESOURCE_TYPE,
                                 "resource_id": self.RESOURCE_ID,
-                                "event_time": epoch_time
+                                "event_time": epoch_time,
+                                "description": self.event
                               },
                               "specific_info": {
                                   "localtime" : self._local_time,
@@ -124,8 +128,7 @@ class HostUpdateMsg(BaseSensorMsg):
                                   "totalMemory" : self._total_memory,
                                   "loggedInUsers" : self._logged_in_users,
                                   "processCount"  : self._process_count,
-                                  "runningProcessCount" : self._running_process_count,
-                                  "event" : self.event
+                                  "runningProcessCount" : self._running_process_count
                                   }
                               }
                           }

--- a/low-level/json_msgs/messages/sensors/host_update.py
+++ b/low-level/json_msgs/messages/sensors/host_update.py
@@ -57,6 +57,7 @@ class HostUpdateMsg(BaseSensorMsg):
                        process_count,
                        running_process_count,
                        alert_type,
+                       event,
                        username  = "SSPL-LL",
                        signature = "N/A",
                        in_time      = "N/A",
@@ -82,6 +83,7 @@ class HostUpdateMsg(BaseSensorMsg):
         self._node_id           = node_id
         self._cluster_id        = cluster_id
         self.alert_type         = alert_type
+        self.event              = event
 
         epoch_time = str(int(time.time()))
         alert_id = mon_utils.get_alert_id(epoch_time)
@@ -122,7 +124,8 @@ class HostUpdateMsg(BaseSensorMsg):
                                   "totalMemory" : self._total_memory,
                                   "loggedInUsers" : self._logged_in_users,
                                   "processCount"  : self._process_count,
-                                  "runningProcessCount" : self._running_process_count
+                                  "runningProcessCount" : self._running_process_count,
+                                  "event" : self.event
                                   }
                               }
                           }

--- a/low-level/json_msgs/messages/sensors/iem_data.py
+++ b/low-level/json_msgs/messages/sensors/iem_data.py
@@ -67,7 +67,8 @@ class IEMDataMsg(BaseSensorMsg):
                         "node_id": info.get("node_id"),
                         "cluster_id": info.get("cluster_id"),
                         "rack_id": info.get("rack_id"),
-                        "resource_type": "iem"
+                        "resource_type": "iem",
+                        "description": info.get("description")
                     },
                     "alert_type": info.get("alert_type"),
                     "severity": info.get("severity"),
@@ -76,7 +77,6 @@ class IEMDataMsg(BaseSensorMsg):
                         "component": info.get("component_id"),
                         "module": info.get("module_id"),
                         "event": info.get("event_id"),
-                        "description": info.get("description"),
                         "IEC": info.get("IEC")
                     },
                     "alert_id": mon_utils.get_alert_id(self._epoch_time),

--- a/low-level/json_msgs/messages/sensors/if_data.py
+++ b/low-level/json_msgs/messages/sensors/if_data.py
@@ -96,12 +96,12 @@ class IFdataMsg(BaseSensorMsg):
                                 "node_id": self._node_id,
                                 "cluster_id": self._cluster_id,
                                 "rack_id": self._rack_id,
-                                "resource_type": self._resource_type
+                                "resource_type": self._resource_type,
+                                "description": event
                              },
                              "specific_info": {
                                 "localtime": self._local_time,
-                                "interfaces": self._interfaces,
-                                "event": event
+                                "interfaces": self._interfaces
                              },
                              "host_id": self._host_id,
                              "alert_type":self.alert_type,

--- a/low-level/json_msgs/messages/sensors/raid_data.py
+++ b/low-level/json_msgs/messages/sensors/raid_data.py
@@ -69,6 +69,7 @@ class RAIDdataMsg(BaseSensorMsg):
         self._event_time = self._sensor_info.get("event_time")
         self._device = self._sensor_specific_info.get("device")
         self._drive = self._sensor_specific_info.get("drives")
+        description = self._sensor_info.get("description")
 
         self._json = {"title" : self.TITLE,
                       "description" : self.DESCRIPTION,
@@ -96,6 +97,7 @@ class RAIDdataMsg(BaseSensorMsg):
                                             "resource_id": self._resource_id,
                                             "resource_type": self._resource_type,
                                             "event_time": self._event_time,
+                                            "description": description
                                         },
                                     "specific_info": {
                                             "device": self._device,

--- a/low-level/json_msgs/messages/sensors/raid_integrity_msg.py
+++ b/low-level/json_msgs/messages/sensors/raid_integrity_msg.py
@@ -96,6 +96,7 @@ class RAIDIntegrityMsg(BaseSensorMsg):
                                             "resource_id": self._resource_id,
                                             "resource_type": self._resource_type,
                                             "event_time": self._event_time,
+                                            "description": self._error_msg
                                         },
                                     "specific_info": {
                                             "error": self._error_msg

--- a/low-level/json_msgs/messages/sensors/realstor_controller_data.py
+++ b/low-level/json_msgs/messages/sensors/realstor_controller_data.py
@@ -66,6 +66,7 @@ class RealStorControllerDataMsg(BaseSensorMsg):
         self._resource_id = self._fru_info.get("resource_id")
         self._resource_type = self._fru_info.get("resource_type")
         self._event_time = self._fru_info.get("event_time")
+        description = self._fru_specific_info.get("health-reason")
 
         self._json = {"title": self.TITLE,
                       "description": self.DESCRIPTION,
@@ -92,7 +93,8 @@ class RealStorControllerDataMsg(BaseSensorMsg):
                                       "cluster_id": self._cluster_id,
                                       "resource_type": self._resource_type,
                                       "event_time": self._event_time,
-                                      "resource_id": self._resource_id
+                                      "resource_id": self._resource_id,
+                                      "description": description
                                   },
                               "specific_info": self._fru_specific_info
                           }

--- a/low-level/json_msgs/messages/sensors/realstor_disk_data.py
+++ b/low-level/json_msgs/messages/sensors/realstor_disk_data.py
@@ -61,6 +61,7 @@ class RealStorDiskDataMsg(BaseSensorMsg):
         self._resource_id = self._fru_info.get("resource_id")
         self._resource_type = self._fru_info.get("resource_type")
         self._event_time = self._fru_info.get("event_time")
+        description = self._fru_specific_info.get("health-reason")
 
         self._json = {"title": self.TITLE,
                       "description": self.DESCRIPTION,
@@ -87,7 +88,8 @@ class RealStorDiskDataMsg(BaseSensorMsg):
                                             "cluster_id": self._cluster_id,
                                             "resource_type": self._resource_type,
                                             "event_time": self._event_time,
-                                            "resource_id": self._resource_id
+                                            "resource_id": self._resource_id,
+                                            "description": description
                                         },
                                     "specific_info": self._fru_specific_info
                                 }

--- a/low-level/json_msgs/messages/sensors/realstor_encl_data_msg.py
+++ b/low-level/json_msgs/messages/sensors/realstor_encl_data_msg.py
@@ -63,6 +63,7 @@ class RealStorEnclDataMsg(BaseSensorMsg):
         self._resource_id = self._encl_info.get("resource_id")
         self._resource_type = self._encl_info.get("resource_type")
         self._event_time = self._encl_info.get("event_time")
+        description = self._specific_info.get("event")
 
         self._json = {"title": self.TITLE,
                     "description": self.DESCRIPTION,
@@ -89,7 +90,8 @@ class RealStorEnclDataMsg(BaseSensorMsg):
                                 "cluster_id": self._cluster_id,
                                 "resource_id": self._resource_id,
                                 "resource_type": self._resource_type,
-                                "event_time": self._event_time
+                                "event_time": self._event_time,
+                                "description": description
                             },
 
                         "specific_info": self._specific_info

--- a/low-level/json_msgs/messages/sensors/realstor_fan_data.py
+++ b/low-level/json_msgs/messages/sensors/realstor_fan_data.py
@@ -61,6 +61,7 @@ class RealStorFanDataMsg(BaseSensorMsg):
         self._resource_id = self._fru_info.get("resource_id")
         self._resource_type = self._fru_info.get("resource_type")
         self._event_time = self._fru_info.get("event_time")
+        description = self._fru_specific_info.get("health-reason")
 
         self._json = {"title": self.TITLE,
                       "description": self.DESCRIPTION,
@@ -87,7 +88,8 @@ class RealStorFanDataMsg(BaseSensorMsg):
                                             "cluster_id": self._cluster_id,
                                             "resource_type": self._resource_type,
                                             "event_time": self._event_time,
-                                            "resource_id": self._resource_id
+                                            "resource_id": self._resource_id,
+                                            "description": description
                                         },
                                     "specific_info": self._fru_specific_info
                                 }

--- a/low-level/json_msgs/messages/sensors/realstor_logical_volume_data.py
+++ b/low-level/json_msgs/messages/sensors/realstor_logical_volume_data.py
@@ -67,6 +67,7 @@ class RealStorLogicalVolumeDataMsg(BaseSensorMsg):
         self._resource_id = self._fru_info.get("resource_id")
         self._resource_type = self._fru_info.get("resource_type")
         self._event_time = self._fru_info.get("event_time")
+        description = self._fru_specific_info.get("health-reason")
 
         self._json = {"title": self.TITLE,
                       "description": self.DESCRIPTION,
@@ -93,7 +94,8 @@ class RealStorLogicalVolumeDataMsg(BaseSensorMsg):
                                       "cluster_id": self._cluster_id,
                                       "resource_type": self._resource_type,
                                       "event_time": self._event_time,
-                                      "resource_id": self._resource_id
+                                      "resource_id": self._resource_id,
+                                      "description": description
                               },
                               "specific_info": self._fru_specific_info
                           }

--- a/low-level/json_msgs/messages/sensors/realstor_psu_data.py
+++ b/low-level/json_msgs/messages/sensors/realstor_psu_data.py
@@ -60,6 +60,7 @@ class RealStorPSUDataMsg(BaseSensorMsg):
         self._resource_id = self._fru_info.get("resource_id")
         self._resource_type = self._fru_info.get("resource_type")
         self._event_time = self._fru_info.get("event_time")
+        description = self._fru_specific_info.get("health-reason")
 
         self._json = {"title": self.TITLE,
                       "description": self.DESCRIPTION,
@@ -86,7 +87,8 @@ class RealStorPSUDataMsg(BaseSensorMsg):
                                             "cluster_id": self._cluster_id,
                                             "resource_type": self._resource_type,
                                             "event_time": self._event_time,
-                                            "resource_id": self._resource_id
+                                            "resource_id": self._resource_id,
+                                            "description": description
                                         },
                                     "specific_info": self._fru_specific_info
                                 }

--- a/low-level/json_msgs/messages/sensors/realstor_sideplane_expander_data.py
+++ b/low-level/json_msgs/messages/sensors/realstor_sideplane_expander_data.py
@@ -61,6 +61,7 @@ class RealStorSideplaneExpanderDataMsg(BaseSensorMsg):
         self._resource_id = self._fru_info.get("resource_id")
         self._resource_type = self._fru_info.get("resource_type")
         self._event_time = self._fru_info.get("event_time")
+        description = self._fru_specific_info.get("health-reason")
 
         self._json = {"title": self.TITLE,
                       "description": self.DESCRIPTION,
@@ -87,7 +88,8 @@ class RealStorSideplaneExpanderDataMsg(BaseSensorMsg):
                                             "cluster_id": self._cluster_id,
                                             "resource_type": self._resource_type,
                                             "event_time": self._event_time,
-                                            "resource_id": self._resource_id
+                                            "resource_id": self._resource_id,
+                                            "description": description
                                     },
                                     "specific_info": self._fru_specific_info
                                 }

--- a/low-level/json_msgs/schemas/sensors/SSPL-LL_Sensor_Response.json
+++ b/low-level/json_msgs/schemas/sensors/SSPL-LL_Sensor_Response.json
@@ -331,6 +331,11 @@
 											"description": "ID which uniquely identifies the resource/instance",
 											"type": "string",
 											"required": true
+										},
+										"description": {
+											"description": "description about alert",
+											"type": "string",
+											"required": true
 										}
 									}
 								},
@@ -780,6 +785,11 @@
 												"unhealthy_components":{
 													"type": "array",
 													"required": false
+                                                },
+                                                "description": {
+                                                    "description": "description about alert",
+                                                    "type": "string",
+                                                    "required": true 
 												}
 										}}
 									}
@@ -853,7 +863,12 @@
                                             "description": "ID which uniquely identifies the resource/instance",
                                             "type": "string",
                                             "required": true
-                                                }
+                                                },
+										"description": {
+											"description": "description about alert",
+											"type": "string",
+											"required": true
+										}
                                             }
                                         },
                                 "specific_info": {

--- a/low-level/sensors/impl/centos_7/systemd_watchdog.py
+++ b/low-level/sensors/impl/centos_7/systemd_watchdog.py
@@ -1184,6 +1184,17 @@ class SystemdWatchdog(SensorThread, InternalMsgQ):
     def _send_msg(self, alert_type, resource_type, resource_id, specific_info):
         """Sends an internal msg to DiskMsgHandler"""
 
+        if alert_type == self.DISK_FAULT_ALERT_TYPE:
+            description = "Fault detected for server drive."
+        elif alert_type == self.DISK_FAULT_RESOLVED_ALERT_TYPE:
+            description = "Fault resolved for server drive."
+        elif alert_type == self.DISK_INSERTED_ALERT_TYPE:
+            description = "Server drive is inserted."
+        elif alert_type == self.DISK_REMOVED_ALERT_TYPE:
+            description = "Server drive is missing."
+        else:
+            description = "Server drive alert."
+
         event_time = str(int(time.time()))
         severity_reader = SeverityReader()
         msg =  {"sensor_response_type" : "node_disk",
@@ -1199,7 +1210,9 @@ class SystemdWatchdog(SensorThread, InternalMsgQ):
                         "cluster_id": self._cluster_id,
                         "resource_type": resource_type,
                         "resource_id": resource_id,
-                        "event_time": event_time},
+                        "event_time": event_time,
+                        "description": description
+                        },
                     "specific_info": specific_info
                     }
                 }

--- a/low-level/sensors/impl/generic/cpu_fault_sensor.py
+++ b/low-level/sensors/impl/generic/cpu_fault_sensor.py
@@ -232,15 +232,24 @@ class CPUFaultSensor(SensorThread, InternalMsgQ):
         # Populate specific info
         self.fill_specific_info()
         alert_specific_info = self.specific_info
+        res_id = self.RESOURCE_ID + str(cpu)
+
+        for item in alert_specific_info:
+            if item['resource_id'] == res_id:
+                if alert_type == "fault":
+                    description = "Faulty CPU detected, %s state is %s" %(item['resource_id'], item["state"])
+                else:
+                    description = "Fault resolved for CPU, %s state is  %s" %(item['resource_id'], item["state"])
 
         info = {
                 "site_id": self._site_id,
                 "cluster_id": self._cluster_id,
                 "rack_id": self._rack_id,
                 "node_id": self._node_id,
-                "resource_type": self.RESOURCE_TYPE,
+                "resource_type": res_id,
                 "resource_id": self.RESOURCE_ID + str(cpu),
-                "event_time": epoch_time
+                "event_time": epoch_time,
+                "description": description
                 }
 
         internal_json_msg = json.dumps(

--- a/low-level/sensors/impl/generic/node_hw.py
+++ b/low-level/sensors/impl/generic/node_hw.py
@@ -682,11 +682,11 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
                 "cluster_id":self._cluster_id,
                 "resource_type": resource_type,
                 "resource_id": resource_id,
-                "event_time": epoch_time
+                "event_time": epoch_time,
+                "description": channel_status
             }
 
         specific_info = {
-                "event": channel_status,
                 "channel info": channel_info
             }
 
@@ -922,7 +922,8 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
                         "cluster_id":self._cluster_id ,
                         "resource_type": resource_type,
                         "resource_id": sensor_name,
-                        "event_time": self._get_epoch_time_from_date_and_time(date, _time)
+                        "event_time": self._get_epoch_time_from_date_and_time(date, _time),
+                        "description": event
                     }
 
         if is_last:
@@ -960,7 +961,8 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
             "cluster_id": self._cluster_id,
             "resource_type": resource_type,
             "resource_id": sensor,
-            "event_time": self._get_epoch_time_from_date_and_time(date, _time)
+            "event_time": self._get_epoch_time_from_date_and_time(date, _time),
+            "description": event
         }
 
         try:
@@ -972,7 +974,7 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
         dynamic, static = self._get_sensor_sdr_props(sensor_id)
         specific_info = {}
         specific_info["fru_id"] = sensor
-        specific_info["event"] = event
+
         specific_info.update(static)
 
         # Remove unnecessary characters props
@@ -1037,7 +1039,8 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
             "cluster_id": self._cluster_id,
             "resource_type": resource_type,
             "resource_id": sensor,
-            "event_time": self._get_epoch_time_from_date_and_time(date, _time)
+            "event_time": self._get_epoch_time_from_date_and_time(date, _time),
+            "description": event
         }
 
         try:
@@ -1049,7 +1052,7 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
         dynamic, static = self._get_sensor_sdr_props(sensor_id)
         specific_info = {}
         specific_info["fru_id"] = sensor
-        specific_info["event"] = event
+
         specific_info.update(static)
 
         for key in ['Deassertions Enabled', 'Assertions Enabled',
@@ -1076,6 +1079,8 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
             disk_sensors_list = self._get_sensor_list_by_entity(common['Entity ID'])
             disk_sensors_list.remove(sensor_id)
 
+            description = f"{event} - {status}"
+
             if not specific:
                 specific = {"States Asserted": "N/A", "Sensor Type (Discrete)": "N/A"}
             specific_info = specific
@@ -1092,7 +1097,8 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
                 "cluster_id": self._cluster_id,
                 "resource_type": resource_type,
                 "resource_id": sensor,
-                "event_time": self._get_epoch_time_from_date_and_time(date, _time)
+                "event_time": self._get_epoch_time_from_date_and_time(date, _time),
+                "description": description
             }
             if (event, status) in alert_severity_dict:
                 alert_type = alert_severity_dict[(event, status)][0]
@@ -1101,7 +1107,6 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
                 alert_type = "fault"
                 severity   = "informational"
             specific_info["fru_id"] = sensor
-            specific_info["event"] = f"{event} - {status}"
 
             if is_last:
                 specific_info.update(specific_dynamic)
@@ -1140,7 +1145,7 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
         specific_info = {}
         specific_info.update(common)
         specific_info.update(specific)
-        specific_info.update({'fru_id': sensor, 'event': event})
+        specific_info.update({'fru_id': sensor})
         if is_last:
             specific_info.update(specific_dynamic)
 
@@ -1151,7 +1156,8 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
             "cluster_id":self._cluster_id ,
             "resource_type": resource_type,
             "resource_id": sensor_name,
-            "event_time": self._get_epoch_time_from_date_and_time(date, _time)
+            "event_time": self._get_epoch_time_from_date_and_time(date, _time),
+            "description": event
         }
 
         self._send_json_msg(resource_type, alert_type, severity, info, specific_info)
@@ -1180,7 +1186,7 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
         specific_info = {}
         specific_info.update(common)
         specific_info.update(specific)
-        specific_info.update({'fru_id': sensor, 'event': event})
+        specific_info.update({'fru_id': sensor})
         if is_last:
             specific_info.update(specific_dynamic)
 
@@ -1191,7 +1197,8 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
             "cluster_id":self._cluster_id ,
             "resource_type": resource_type,
             "resource_id": sensor_name,
-            "event_time": self._get_epoch_time_from_date_and_time(date, _time)
+            "event_time": self._get_epoch_time_from_date_and_time(date, _time),
+            "description": event
         }
 
         self._send_json_msg(resource_type, alert_type, severity, info, specific_info)
@@ -1222,7 +1229,7 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
 #        specific_info = {}
 #        specific_info.update(common)
 #        specific_info.update(specific)
-#        specific_info.update({'fru_id': sensor, 'event': event})
+#        specific_info.update({'fru_id': sensor})
 #        if is_last:
 #            specific_info.update(specific_dynamic)
 #
@@ -1233,7 +1240,8 @@ class NodeHWsensor(SensorThread, InternalMsgQ):
 #            "cluster_id":self._cluster_id ,
 #            "resource_type": resource_type,
 #            "resource_id": sensor_name,
-#            "event_time": self._get_epoch_time_from_date_and_time(date, _time)
+#            "event_time": self._get_epoch_time_from_date_and_time(date, _time),
+#            "description": event
 #        }
 #
 #        self._send_json_msg(resource_type, alert_type, severity, info, specific_info)

--- a/low-level/sensors/impl/generic/node_memory_fault.py
+++ b/low-level/sensors/impl/generic/node_memory_fault.py
@@ -217,11 +217,11 @@ class MemFaultSensor(SensorThread, InternalMsgQ):
         specific_info = {}
         specific_info_list = []
         if alert_type == "fault":
-            specific_info["event"] = \
+            description  = \
                     "Total available main memory value decreased from {} kB to {} kB"\
                     .format(self.prev_mem, self.total_mem)
         elif alert_type == "fault_resolved":
-            specific_info["event"] = \
+            description  = \
                     "Total main memory value available {} kB"\
                     .format(self.total_mem)
 
@@ -240,7 +240,8 @@ class MemFaultSensor(SensorThread, InternalMsgQ):
             "node_id": self._node_id,
             "resource_type": self.RESOURCE_TYPE,
             "resource_id": self.RESOURCE_ID,
-            "event_time": epoch_time
+            "event_time": epoch_time,
+            "description": description
             }
 
         internal_json_msg = json.dumps(

--- a/low-level/sensors/impl/generic/node_sas_port.py
+++ b/low-level/sensors/impl/generic/node_sas_port.py
@@ -421,10 +421,10 @@ class SASPortSensor(SensorThread, InternalMsgQ):
         if port != -1:
             # This is a port level alert, add an error key in specific info
             if alert_type == 'fault':
-                specific_info["error"] = f"No connectivity detected on the SAS port {port}, possible \
-causes could be missing SAS cable, bad cable connection, faulty cable or SAS port failure"
+                description  = f"No connectivity detected on the SAS port {port}, possible \
+causes could be missing SAS cable, bad cable connection, faulty cable or SAS port failure."
             elif alert_type == 'fault_resolved':
-                specific_info["error"] = "null"
+                description  = "Connection established on SAS port."
             specific_info_list.append(specific_info)
             specific_info = {}
 
@@ -455,7 +455,8 @@ causes could be missing SAS cable, bad cable connection, faulty cable or SAS por
                     "node_id": self._node_id,
                     "resource_type": self.RESOURCE_TYPE, # node:interface:sas
                     "resource_id": self.RESOURCE_ID, # SASHBA-0
-                    "event_time": epoch_time
+                    "event_time": epoch_time,
+                    "description": description
                     }
         else:
             # This is a port level alert
@@ -466,7 +467,8 @@ causes could be missing SAS cable, bad cable connection, faulty cable or SAS por
                     "node_id": self._node_id,
                     "resource_type": self.RESOURCE_TYPE + ':port', # node:interface:sas:port
                     "resource_id": self.RESOURCE_ID + f'-port-{port}', # SASHBA-0-port-0
-                    "event_time": epoch_time
+                    "event_time": epoch_time,
+                    "description": description
                     }
 
         internal_json_msg = json.dumps(

--- a/low-level/sensors/impl/generic/raid.py
+++ b/low-level/sensors/impl/generic/raid.py
@@ -451,6 +451,17 @@ class RAIDsensor(SensorThread, InternalMsgQ):
         self._alert_id = self._get_alert_id(epoch_time)
         host_name = socket.getfqdn()
 
+        if alert_type == self.MISSING:
+            description = "RAID array or drive from RAID array is missing."
+        elif alert_type == self.FAULT:
+            description = "RAID array or drive from RAID array is faulty."
+        elif alert_type == self.INSERTION:
+            description = "Inserted drive in RAID array."
+        elif alert_type == self.FAULT_RESOLVED:
+            description = "Fault for RAID array or RAID drive is resolved"
+        else:
+            description = "Raid array alert"
+
         info = {
                 "site_id": self._site_id,
                 "cluster_id": self._cluster_id,
@@ -458,7 +469,8 @@ class RAIDsensor(SensorThread, InternalMsgQ):
                 "node_id": self._node_id,
                 "resource_type": self.RESOURCE_TYPE,
                 "resource_id": resource_id,
-                "event_time": epoch_time
+                "event_time": epoch_time,
+                "description": description
                }
         specific_info = {
             "device": device,

--- a/low-level/sensors/impl/generic/raid_integrity_data.py
+++ b/low-level/sensors/impl/generic/raid_integrity_data.py
@@ -344,7 +344,8 @@ class RAIDIntegritySensor(SensorThread, InternalMsgQ):
                 "node_id": self._node_id,
                 "resource_type": self.RESOURCE_TYPE,
                 "resource_id": resource_id,
-                "event_time": epoch_time
+                "event_time": epoch_time,
+                "description": error_msg
                }
         specific_info = {
             "error": error_msg

--- a/low-level/sensors/impl/platforms/realstor/realstor_enclosure_sensor.py
+++ b/low-level/sensors/impl/platforms/realstor/realstor_enclosure_sensor.py
@@ -197,7 +197,8 @@ class RealStorEnclosureSensor(SensorThread, InternalMsgQ):
                 "node_id": self.rssencl.node_id,
                 "resource_type": self.RESOURCE_TYPE,
                 "resource_id": resource_id,
-                "event_time": epoch_time
+                "event_time": epoch_time,
+                "description": encl_status
             }
 
         internal_json_msg = json.dumps(

--- a/sspl_test/alerts/node/test_node_bmc_interface.py
+++ b/sspl_test/alerts/node/test_node_bmc_interface.py
@@ -77,10 +77,11 @@ def test_bmc_interface(args):
     assert(bmc_interface_info.get("node_id") is not None)
     assert(bmc_interface_info.get("cluster_id") is not None)
     assert(bmc_interface_info.get("resource_id") is not None)
+    assert(bmc_interface_info.get("description") is not None )
 
     bmc_interface_specific_info = bmc_interface_message.get("specific_info")
     if bmc_interface_specific_info:
-        assert(bmc_interface_specific_info.get("event") is not None)
+        assert(bmc_interface_specific_info.get("channel info") is not None)
 
 def backup_bmc_config():
     # read active bmc interface

--- a/sspl_test/alerts/os/test_disk_space_alert.py
+++ b/sspl_test/alerts/os/test_disk_space_alert.py
@@ -63,6 +63,7 @@ def test_disk_space_alert(agrs):
     assert(disk_space_info.get("resource_type") is not None)
     assert(disk_space_info.get("event_time") is not None)
     assert(disk_space_info.get("resource_id") is not None)
+    assert(disk_space_info.get("description") is not None)
 
     disk_space_specific_info = disk_space_sensor_msg.get("specific_info")
     assert(disk_space_specific_info is not None)

--- a/sspl_test/alerts/os/test_node_cpu_data_sensor.py
+++ b/sspl_test/alerts/os/test_node_cpu_data_sensor.py
@@ -61,6 +61,7 @@ def test_cpu_data_sensor(args):
     assert(info.get("resource_type") is not None)
     assert(info.get("event_time") is not None)
     assert(info.get("resource_id") is not None)
+    assert(info.get("description") is not None)
 
     specific_info = cpu_data_msg.get("specific_info")
     assert(specific_info.get("systemTime") is not None)

--- a/sspl_test/alerts/os/test_node_cpu_data_sensor.py
+++ b/sspl_test/alerts/os/test_node_cpu_data_sensor.py
@@ -28,7 +28,7 @@ def init(args):
 
 def test_cpu_data_sensor(args):
     check_sspl_ll_is_running()
-    node_data_sensor_message_request("node:os:cpu")
+    node_data_sensor_message_request("node:os:cpu_usage")
     cpu_data_msg = None
     sleep(10)
     while not world.sspl_modules[RabbitMQingressProcessorTests.name()]._is_my_msgQ_empty():
@@ -38,7 +38,7 @@ def test_cpu_data_sensor(args):
         try:
             # Make sure we get back the message type that matches the request
             msg_type = ingressMsg.get("sensor_response_type")
-            if msg_type.get("info").get("resource_type") == "node:os:cpu":
+            if msg_type.get("info").get("resource_type") == "node:os:cpu_usage":
                 cpu_data_msg = msg_type
                 break
         except Exception as exception:

--- a/sspl_test/alerts/os/test_node_host_data_sensor.py
+++ b/sspl_test/alerts/os/test_node_host_data_sensor.py
@@ -61,6 +61,7 @@ def test_host_update_data_sensor(args):
     assert(info.get("resource_type") is not None)
     assert(info.get("event_time") is not None)
     assert(info.get("resource_id") is not None)
+    assert(info.get("description") is not None)
 
     specific_info = host_update_msg.get("specific_info")
     assert(specific_info.get("loggedInUsers") is not None)

--- a/sspl_test/alerts/os/test_node_if_data_sensor.py
+++ b/sspl_test/alerts/os/test_node_if_data_sensor.py
@@ -64,6 +64,7 @@ def test_if_data_sensor(args):
     assert(if_data_info.get("resource_type") is not None)
     assert(if_data_info.get("event_time") is not None)
     assert(if_data_info.get("resource_id") is not None)
+    assert(if_data_info.get("description") is not None)
 
     if_data_specific_info = if_data_msg.get("specific_info")
     assert(if_data_specific_info is not None)

--- a/sspl_test/alerts/os/test_node_raid_integrity_sensor.py
+++ b/sspl_test/alerts/os/test_node_raid_integrity_sensor.py
@@ -65,6 +65,7 @@ def test_raid_integrity_sensor(args):
     assert(info.get("resource_type") is not None)
     assert(info.get("event_time") is not None)
     assert(info.get("resource_id") is not None)
+    assert(info.get("description") is not None)
 
     specific_info = raid_data_msg.get("specific_info")
     assert(specific_info.get("error") is None)

--- a/sspl_test/alerts/realstor/test_real_stor_controller_sensor.py
+++ b/sspl_test/alerts/realstor/test_real_stor_controller_sensor.py
@@ -61,6 +61,7 @@ def test_real_stor_controller_sensor(agrs):
     assert(info.get("resource_type") is not None)
     assert(info.get("event_time") is not None)
     assert(info.get("resource_id") is not None)
+    assert(info.get("description") is not None)
 
     specific_info = controller_sensor_msg.get("specific_info")
     assert(specific_info.get("object_name") is not None)

--- a/sspl_test/alerts/realstor/test_real_stor_disk_sensor.py
+++ b/sspl_test/alerts/realstor/test_real_stor_disk_sensor.py
@@ -61,6 +61,7 @@ def test_real_stor_disk_sensor(agrs):
     assert(disk_sensor_info.get("resource_type") is not None)
     assert(disk_sensor_info.get("event_time") is not None)
     assert(disk_sensor_info.get("resource_id") is not None)
+    assert(disk_sensor_info.get("description") is not None)
 
     disk_sensor_specific_info = disk_sensor_msg.get("specific_info")
     assert(disk_sensor_specific_info is not None)

--- a/sspl_test/alerts/realstor/test_real_stor_enclosure_sensor.py
+++ b/sspl_test/alerts/realstor/test_real_stor_enclosure_sensor.py
@@ -69,6 +69,7 @@ def test_real_stor_enclosure_sensor(agrs):
     assert(encl_sensor_info.get("resource_id") is not None)
     assert(encl_sensor_info.get("resource_type") is not None)
     assert(encl_sensor_info.get("event_time") is not None)
+    assert(encl_sensor_info.get("description") is not None)
 
     encl_specific_info = encl_sensor_msg.get("specific_info")
     if encl_specific_info:

--- a/sspl_test/alerts/realstor/test_real_stor_fan_sensor.py
+++ b/sspl_test/alerts/realstor/test_real_stor_fan_sensor.py
@@ -61,6 +61,7 @@ def test_real_stor_fan_module_sensor(agrs):
     assert(fan_module_info.get("resource_type") is not None)
     assert(fan_module_info.get("event_time") is not None)
     assert(fan_module_info.get("resource_id") is not None)
+    assert(fan_module_info.get("description") is not None)
 
     fru_specific_info = fan_module_sensor_msg.get("specific_info", {})
     if fru_specific_info:

--- a/sspl_test/alerts/realstor/test_real_stor_psu_sensor.py
+++ b/sspl_test/alerts/realstor/test_real_stor_psu_sensor.py
@@ -62,6 +62,8 @@ def test_real_stor_psu_sensor(args):
     assert(psu_info.get("resource_type") is not None)
     assert(psu_info.get("resource_id") is not None)
     assert(psu_info.get("event_time") is not None)
+    assert(psu_info.get("description") is not None)
+    
     psu_specific_info = psu_sensor_msg.get("specific_info")
     assert(psu_specific_info is not None)
     assert(psu_specific_info.get("enclosure_id") is not None)

--- a/sspl_test/alerts/realstor/test_real_stor_psu_sensor.py
+++ b/sspl_test/alerts/realstor/test_real_stor_psu_sensor.py
@@ -53,6 +53,7 @@ def test_real_stor_psu_sensor(args):
     assert(psu_sensor_msg.get("alert_type") is not None)
     assert(psu_sensor_msg.get("severity") is not None)
     assert(psu_sensor_msg.get("alert_id") is not None)
+
     psu_info = psu_sensor_msg.get("info")
     assert(psu_info is not None)
     assert(psu_info.get("site_id") is not None)
@@ -63,7 +64,7 @@ def test_real_stor_psu_sensor(args):
     assert(psu_info.get("resource_id") is not None)
     assert(psu_info.get("event_time") is not None)
     assert(psu_info.get("description") is not None)
-    
+
     psu_specific_info = psu_sensor_msg.get("specific_info")
     assert(psu_specific_info is not None)
     assert(psu_specific_info.get("enclosure_id") is not None)

--- a/sspl_test/alerts/realstor/test_real_stor_sideplane_expander_sensor.py
+++ b/sspl_test/alerts/realstor/test_real_stor_sideplane_expander_sensor.py
@@ -61,6 +61,7 @@ def test_real_stor_sideplane_expander_sensor(agrs):
     assert(sideplane_expander_info_data.get("resource_type") is not None)
     assert(sideplane_expander_info_data.get("event_time") is not None)
     assert(sideplane_expander_info_data.get("resource_id") is not None)
+    assert(sideplane_expander_info_data.get("description") is not None)
 
     sideplane_expander_specific_info_data = sideplane_expander_sensor_msg.get("specific_info", {})
 


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    Improvement for node data alerts(cpu_usage, disk-space ,memeory_usage).
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Please add Problem decription here...
  </code>
</pre>
## Solution
<pre>
  <code>
    Renamed resource type node:oscpu to node:os:cpu_usage.
    Added  description field  in all sensor response.
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
 
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Tested by simulating these alerts on vm by changing threshold value in /etc/sspl.conf file.
    
    CPU_usage alert example:
    
  ```
 {
  "username": "sspl-ll",
  "description": "Seagate Storage Platform Library - Sensor Response",
  "title": "SSPL Sensor Response",
  "expires": 3600,
  "signature": "None",
  "time": "1613363821",
  "message": {
    "sspl_ll_msg_header": {
      "schema_version": "1.0.0",
      "sspl_version": "1.0.0",
      "msg_version": "1.0.0"
    },
    "sensor_response_type": {
      "alert_type": "fault",
      "severity": "warning",
      "alert_id": "1613363820e5c1520b824b47d3b31dd5aad6a9a626",
      "host_id": "ssc-vm-2450.colo.seagate.com",
      "info": {
        "site_id": "001",
        "rack_id": "001",
        "node_id": "001",
        "cluster_id": "fa21a093-6b6d-4fce-84e3-324e7c0e3de9",
        "resource_type": "node:os:cpu_usage",
        "resource_id": "0",
        "event_time": "1613363820",
        "description": "CPU usage increased to 13.6, beyond configured threshold of 0"
      },
      "specific_info": {
        "localtime": "1613363319",
        "csps": 0,
        "idleTime": 99,
        "interruptTime": 0,
        "iowaitTime": 0,
        "niceTime": 0,
        "softirqTime": 0,
        "stealTime": 0,
        "systemTime": 0,
        "userTime": 0,
        "coreData": [
          {
            "coreId": 0,
            "load1MinAvg": 14,
            "load5MinAvg": 0,
            "load15MinAvg": 0,
            "ips": 0
          },
          {
            "coreId": 1,
            "load1MinAvg": 21,
            "load5MinAvg": 0,
            "load15MinAvg": 0,
            "ips": 0
          }
        ],
        "cpu_usage": 13.6
      }
    }
  }
}
```
    
    
    
  </code>
</pre>
