### PR TITLE
EOS-13375: Stabilize Failing Sanity Tests on Jenkins

### DIFF
--- a/sspl_test/alerts/os/simulate_network_interface.py
+++ b/sspl_test/alerts/os/simulate_network_interface.py
@@ -36,6 +36,7 @@ def shuffle_nw_interface():
     create_nw_interface()
     sleep(3)
     # Change interface's state from down to up
-    # Default state for eth-mocked and br0 is down.  
+    # Default state for eth-mocked and br0 is down.
     call("ip link set eth-mocked up".split())
+    sleep(.1)
     call("ip link set br0 up".split())

--- a/sspl_test/alerts/os/test_disk_space_alert.py
+++ b/sspl_test/alerts/os/test_disk_space_alert.py
@@ -37,7 +37,7 @@ def test_disk_space_alert(agrs):
     # Wait untill expected resource type found in RMQ ingress processor msgQ.
     start_time = time.time()
     max_wait_time = 60
-    while not disk_space_sensor_msg and (time.time()-start_time) < max_wait_time:
+    while not disk_space_sensor_msg:
         if not world.sspl_modules[RabbitMQingressProcessorTests.name()]._is_my_msgQ_empty():
             ingressMsg = world.sspl_modules[RabbitMQingressProcessorTests.name()]._read_my_msgQ()
             print("Received: {0}".format(ingressMsg))
@@ -48,6 +48,8 @@ def test_disk_space_alert(agrs):
                     disk_space_sensor_msg = msg_type
             except Exception as exception:
                 print(exception)
+        if (time.time()-start_time) > max_wait_time:
+            break
 
     assert(disk_space_sensor_msg is not None)
     assert(disk_space_sensor_msg.get("alert_type") is not None)

--- a/sspl_test/alerts/os/test_disk_space_alert.py
+++ b/sspl_test/alerts/os/test_disk_space_alert.py
@@ -24,28 +24,30 @@ from sspl_test.default import *
 from sspl_test.rabbitmq.rabbitmq_ingress_processor_tests import RabbitMQingressProcessorTests
 from sspl_test.rabbitmq.rabbitmq_egress_processor import RabbitMQegressProcessor
 
+
+resource_type = "node:os:disk_space"
+
 def init(args):
     pass
 
 def test_disk_space_alert(agrs):
     check_sspl_ll_is_running()
-    disk_space_data_sensor_request("node:os:disk_space")
+    disk_space_data_sensor_request(resource_type)
     disk_space_sensor_msg = None
-    time.sleep(4)
-    while not world.sspl_modules[RabbitMQingressProcessorTests.name()]._is_my_msgQ_empty():
-        ingressMsg = world.sspl_modules[RabbitMQingressProcessorTests.name()]._read_my_msgQ()
-        time.sleep(0.1)
-        print("Received: {0}".format(ingressMsg))
-
-        try:
-            # Make sure we get back the message type that matches the request
-            msg_type = ingressMsg.get("sensor_response_type")
-            if msg_type["info"]["resource_type"] == "node:os:disk_space":
-                disk_space_sensor_msg = msg_type
-                break
-        except Exception as exception:
-            time.sleep(0.1)
-            print(exception)
+    # Wait untill expected resource type found in RMQ ingress processor msgQ.
+    start_time = time.time()
+    max_wait_time = 60
+    while not disk_space_sensor_msg and (time.time()-start_time) < max_wait_time:
+        if not world.sspl_modules[RabbitMQingressProcessorTests.name()]._is_my_msgQ_empty():
+            ingressMsg = world.sspl_modules[RabbitMQingressProcessorTests.name()]._read_my_msgQ()
+            print("Received: {0}".format(ingressMsg))
+            try:
+                # Make sure we get back the message type that matches the request
+                msg_type = ingressMsg.get("sensor_response_type")
+                if msg_type["info"]["resource_type"] == resource_type:
+                    disk_space_sensor_msg = msg_type
+            except Exception as exception:
+                print(exception)
 
     assert(disk_space_sensor_msg is not None)
     assert(disk_space_sensor_msg.get("alert_type") is not None)
@@ -60,7 +62,7 @@ def test_disk_space_alert(agrs):
     assert(disk_space_info.get("node_id") is not None)
     assert(disk_space_info.get("cluster_id") is not None)
     assert(disk_space_info.get("rack_id") is not None)
-    assert(disk_space_info.get("resource_type") is not None)
+    assert(disk_space_info.get("resource_type") == resource_type)
     assert(disk_space_info.get("event_time") is not None)
     assert(disk_space_info.get("resource_id") is not None)
     assert(disk_space_info.get("description") is not None)

--- a/sspl_test/alerts/os/test_node_if_data_sensor.py
+++ b/sspl_test/alerts/os/test_node_if_data_sensor.py
@@ -39,7 +39,7 @@ def test_if_data_sensor(args):
     # Wait untill expected resource type found in RMQ ingress processor msgQ.
     start_time = time.time()
     max_wait_time = 60
-    while not if_data_msg and (time.time()-start_time) < max_wait_time:
+    while not if_data_msg:
         if not world.sspl_modules[RabbitMQingressProcessorTests.name()]._is_my_msgQ_empty():
             ingressMsg = world.sspl_modules[RabbitMQingressProcessorTests.name()]._read_my_msgQ()
             print("Received: {0}".format(ingressMsg))
@@ -50,6 +50,8 @@ def test_if_data_sensor(args):
                     if_data_msg = msg_type
             except Exception as exception:
                 print(exception)
+        if (time.time()-start_time) > max_wait_time:
+            break
 
     assert(if_data_msg is not None)
     assert(if_data_msg.get("alert_type") is not None)

--- a/sspl_test/alerts/os/test_node_if_data_sensor.py
+++ b/sspl_test/alerts/os/test_node_if_data_sensor.py
@@ -15,7 +15,7 @@
 
 import json
 import os
-from time import sleep
+import time
 import sys
 
 from sspl_test.alerts.os import simulate_network_interface as mock_eth_interface
@@ -24,29 +24,32 @@ from sspl_test.rabbitmq.rabbitmq_ingress_processor_tests import RabbitMQingressP
 from sspl_test.rabbitmq.rabbitmq_egress_processor import RabbitMQegressProcessor
 from sspl_test.common import check_sspl_ll_is_running
 
+
+resource_type = "node:interface:nw"
+
 def init(args):
     pass
 
 def test_if_data_sensor(args):
     check_sspl_ll_is_running()
-    node_data_sensor_message_request("node:interface:nw")
+    node_data_sensor_message_request(resource_type)
     if_data_msg = None
     #create dummy interface to get network alerts
     mock_eth_interface.shuffle_nw_interface()
-    sleep(10)
-    while not world.sspl_modules[RabbitMQingressProcessorTests.name()]._is_my_msgQ_empty():
-        ingressMsg = world.sspl_modules[RabbitMQingressProcessorTests.name()]._read_my_msgQ()
-        sleep(0.1)
-        print("Received for if_data: {0}".format(ingressMsg))
-        try:
-            # Make sure we get back the message type that matches the request
-            msg_type = ingressMsg.get("sensor_response_type")
-            if msg_type["info"]["resource_type"] == "node:interface:nw":
-                if_data_msg = msg_type
-                break
-        except Exception as exception:
-            sleep(0.1)
-            print(exception)
+    # Wait untill expected resource type found in RMQ ingress processor msgQ.
+    start_time = time.time()
+    max_wait_time = 60
+    while not if_data_msg and (time.time()-start_time) < max_wait_time:
+        if not world.sspl_modules[RabbitMQingressProcessorTests.name()]._is_my_msgQ_empty():
+            ingressMsg = world.sspl_modules[RabbitMQingressProcessorTests.name()]._read_my_msgQ()
+            print("Received: {0}".format(ingressMsg))
+            try:
+                # Make sure we get back the message type that matches the request
+                msg_type = ingressMsg.get("sensor_response_type")
+                if msg_type["info"]["resource_type"] == resource_type:
+                    if_data_msg = msg_type
+            except Exception as exception:
+                print(exception)
 
     assert(if_data_msg is not None)
     assert(if_data_msg.get("alert_type") is not None)
@@ -61,7 +64,7 @@ def test_if_data_sensor(args):
     assert(if_data_info.get("node_id") is not None)
     assert(if_data_info.get("cluster_id") is not None)
     assert(if_data_info.get("rack_id") is not None)
-    assert(if_data_info.get("resource_type") is not None)
+    assert(if_data_info.get("resource_type") == resource_type)
     assert(if_data_info.get("event_time") is not None)
     assert(if_data_info.get("resource_id") is not None)
     assert(if_data_info.get("description") is not None)


### PR DESCRIPTION
The wait time added before looking for message in RMQ ingress processor queue was 10 sec.
While re-running the corresponding failed tests, debug log shows that message is put in queue after 14 sec.
At this time, while loop never enters in as queue is empty.

Also, added resource_type validation.