### PR TITLE
EOS-18452: SAS Port resolved alerts are not coming up on rabbitmq and CSM UI

### DIFF
--- a/low-level/sensors/impl/generic/node_sas_port.py
+++ b/low-level/sensors/impl/generic/node_sas_port.py
@@ -441,6 +441,11 @@ class SASPortSensor(SensorThread, InternalMsgQ):
 
         if port == -1:
             # This is a SAS HBA level connection alert
+            if alert_type == 'fault':
+                description = "SAS connection error detected in SAS HBA %s." %self.RESOURCE_ID
+            elif alert_type == 'fault_resolved':
+                description = "SAS connection re-established in SAS HBA %s." %self.RESOURCE_ID
+
             info = {
                     "site_id": self._site_id,
                     "cluster_id": self._cluster_id,
@@ -454,8 +459,9 @@ class SASPortSensor(SensorThread, InternalMsgQ):
         else:
             # This is a port level alert
             if alert_type == 'fault':
-                description = f"No connectivity detected on the SAS port {port}, possible \
-                                causes could be missing SAS cable, bad cable connection, faulty cable or SAS port failure."
+                description = ("No connectivity detected on the SAS port %s, possible"
+                                "causes could be missing SAS cable, bad cable connection,"
+                                 "faulty cable or SAS port failure." %port)
             elif alert_type == 'fault_resolved':
                 description = "Connection established on SAS port."
             info = {

--- a/low-level/sensors/impl/generic/node_sas_port.py
+++ b/low-level/sensors/impl/generic/node_sas_port.py
@@ -419,7 +419,7 @@ class SASPortSensor(SensorThread, InternalMsgQ):
 
         specific_info = {}
         specific_info_list = []
-
+        description = "N/A"
         if port != -1:
             # This is a port level alert, add an error key in specific info
             if alert_type == 'fault':
@@ -427,8 +427,6 @@ class SASPortSensor(SensorThread, InternalMsgQ):
 causes could be missing SAS cable, bad cable connection, faulty cable or SAS port failure"
             elif alert_type == 'fault_resolved':
                 description = "Connection established on SAS port."
-            specific_info_list.append(specific_info)
-            specific_info = {}
 
         # specific_info will contain all 16 phys for conn level alert
         # Only 4 phys for port level alert

--- a/low-level/sensors/impl/generic/node_sas_port.py
+++ b/low-level/sensors/impl/generic/node_sas_port.py
@@ -420,13 +420,6 @@ class SASPortSensor(SensorThread, InternalMsgQ):
         specific_info = {}
         specific_info_list = []
         description = "N/A"
-        if port != -1:
-            # This is a port level alert, add an error key in specific info
-            if alert_type == 'fault':
-                description = f"No connectivity detected on the SAS port {port}, possible \
-causes could be missing SAS cable, bad cable connection, faulty cable or SAS port failure"
-            elif alert_type == 'fault_resolved':
-                description = "Connection established on SAS port."
 
         # specific_info will contain all 16 phys for conn level alert
         # Only 4 phys for port level alert
@@ -460,6 +453,11 @@ causes could be missing SAS cable, bad cable connection, faulty cable or SAS por
                     }
         else:
             # This is a port level alert
+            if alert_type == 'fault':
+                description = f"No connectivity detected on the SAS port {port}, possible \
+                                causes could be missing SAS cable, bad cable connection, faulty cable or SAS port failure."
+            elif alert_type == 'fault_resolved':
+                description = "Connection established on SAS port."
             info = {
                     "site_id": self._site_id,
                     "cluster_id": self._cluster_id,


### PR DESCRIPTION
CSM UI

## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    SAS Port resolved alerts are not coming up on rabbitmq and CSM UI
  </code>
</pre>
## Problem Description
<pre>
  <code>
     "description" variable referenced before assignment.
  </code>
</pre>
## Solution
<pre>
  <code>
   
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes

  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Please describe the tests that you ran to verify your changes.
  </code>
</pre>
