### PR TITLE
EOS-18520: Optimize Disk Group health check frequency

### DIFF
--- a/low-level/files/opt/seagate/sspl/conf/sspl.conf.LR2.yaml
+++ b/low-level/files/opt/seagate/sspl/conf/sspl.conf.LR2.yaml
@@ -165,7 +165,8 @@ NODEHWSENSOR:
 
 REALSTORLOGICALVOLUMESENSOR:
    threaded: true
-   polling_frequency_override: 0
+   # Polling frequency override here applicable for both Disk Group & Logical Volume monitoring
+   polling_frequency_override: 10
 
 REALSTORENCLOSURESENSOR:
    threaded: true

--- a/low-level/sensors/impl/platforms/realstor/realstor_dg_volume_sensor.py
+++ b/low-level/sensors/impl/platforms/realstor/realstor_dg_volume_sensor.py
@@ -134,12 +134,12 @@ class RealStorLogicalVolumeSensor(SensorThread, InternalMsgQ):
         # Holds Logical Volumes with faults. Used for future reference.
         self._previously_faulty_logical_volumes = {}
 
-        self.pollfreq_logical_volume_sensor = \
+        self.pollfreq_DG_logical_volume_sensor = \
             int(Conf.get(SSPL_CONF, f"{self.rssencl.CONF_REALSTORLOGICALVOLUMESENSOR}>{POLLING_FREQUENCY_OVERRIDE}",
-                            0))
+                            10))
 
-        if self.pollfreq_logical_volume_sensor == 0:
-                self.pollfreq_logical_volume_sensor = self.rssencl.pollfreq
+        if self.pollfreq_DG_logical_volume_sensor == 0:
+                self.pollfreq_DG_logical_volume_sensor = self.rssencl.pollfreq
 
         # Flag to indicate suspension of module
         self._suspended = False
@@ -223,7 +223,7 @@ class RealStorLogicalVolumeSensor(SensorThread, InternalMsgQ):
         self._disable_debug_if_persist_false()
 
         # Fire every 10 seconds to see if We have a faulty Logical Volume
-        self._scheduler.enter(self.pollfreq_logical_volume_sensor,
+        self._scheduler.enter(self.pollfreq_DG_logical_volume_sensor,
                 self._priority, self.run, ())
 
     def _get_disk_groups(self):


### PR DESCRIPTION
## Problem Statement
<pre>
  <code>
    Story Ref (if any):
    Please add Problem statement here...
  </code>
</pre>
## Problem Description
<pre>
  <code>
  Optimize Disk Group health check frequency
  </code>
</pre>
## Solution
<pre>
  <code>
   The default polling frequency for realstor_dg_volume_sensor is 30sec. Optimize it to 10sec. 
  </code>
</pre>
## Sanity testing on RPM done
<pre>
  <code>
    - [ ] Yes
    - [ ] No
  </code>
</pre>
## Unit/Manual Testing Description
<pre>
  <code>
    Please describe the tests that you ran to verify your changes.
  </code>
</pre>
