### PR TITLE
Unittest base structure with pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,0 @@
-import sys
-import os
-
-
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-
-sys.path.append(os.path.join(BASE_DIR, 'low-level'))
-sys.path.append(os.path.join(BASE_DIR, 'low-level', 'framework'))
-

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,9 @@
+import sys
+import os
+
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+sys.path.append(os.path.join(BASE_DIR, 'low-level'))
+sys.path.append(os.path.join(BASE_DIR, 'low-level', 'framework'))
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+# pytest.ini
+[pytest]
+minversion = 6.0
+addopts = -ra -q
+testpaths =
+    unittests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 # pytest.ini
 [pytest]
 minversion = 6.0
+# detailed info on skipped/failed tests and “dot” progress output
 addopts = -ra -q
 testpaths =
     unittests

--- a/unittests/conftest.py
+++ b/unittests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+import os
+
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+sys.path.append(os.path.join(BASE_DIR, 'low-level'))

--- a/unittests/framework/base/test_configuration_upgrade.py
+++ b/unittests/framework/base/test_configuration_upgrade.py
@@ -9,7 +9,7 @@ PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__)).replace(
     "sspl_test", "low-level/framework"
 )
 sys.path.append(PROJECT_ROOT)
-from base.conf_upgrade import ConfUpgrade
+from framework.base.conf_upgrade import ConfUpgrade
 
 
 class TestConfUpgrade(unittest.TestCase):

--- a/unittests/framework/base/test_configuration_upgrade.py
+++ b/unittests/framework/base/test_configuration_upgrade.py
@@ -17,7 +17,7 @@ class TestConfUpgrade(unittest.TestCase):
     def setUp(self):
         base_config = "low-level/files/opt/seagate/sspl/conf/sspl.conf.LR2.yaml"
         base_config = os.path.dirname(os.path.abspath(__file__)).replace(
-                                      "sspl_test", base_config)
+                                      "unittests/framework/base", base_config)
         base_config_url = f"yaml://{base_config}"
         self.tmp_dir = "/opt/seagate/cortx/sspl/tmp"
         self.existing_config = f"/{self.tmp_dir}/existing.conf"

--- a/unittests/message_handlers/test_service_msg_handler.py
+++ b/unittests/message_handlers/test_service_msg_handler.py
@@ -19,7 +19,10 @@ class TestServiceMsgHandler(unittest.TestCase):
         self.service_msg_handler.host_id = 1
 
     def test_create_actuator_response(self):
-        msg = self.service_msg_handler._create_actuator_response(self.service_info)
-        assert msg['host_id'] == 1
-        assert msg['instance_id'] == 'kafka'
-        assert msg['specific_info'][0]['service_name'] == 'kafka'
+        resp_msg = self.service_msg_handler._create_actuator_response(self.service_info)
+        assert resp_msg['host_id'] == 1
+        assert resp_msg['instance_id'] == 'kafka'
+        assert resp_msg['specific_info'][0]['service_name'] == 'kafka'
+        assert resp_msg['specific_info'][0]['status'] == 'failed'
+        assert resp_msg['alert_type'] == 'UPDATE'
+        assert resp_msg['info']['resource_type'] == 'node:sw:os:service'

--- a/unittests/message_handlers/test_service_msg_handler.py
+++ b/unittests/message_handlers/test_service_msg_handler.py
@@ -1,0 +1,25 @@
+import unittest
+
+from message_handlers.service_msg_handler import ServiceMsgHandler
+
+
+class TestServiceMsgHandler(unittest.TestCase):
+    service_info = {
+            'service_name': 'kafka',
+            'status': 'failed'
+        }
+
+    def setUp(self) -> None:
+        self.service_msg_handler = ServiceMsgHandler()
+        self.service_msg_handler.cluster_id = 1
+        self.service_msg_handler.site_id = 1
+        self.service_msg_handler.rack_id = 1
+        self.service_msg_handler.node_id = 1
+        self.service_msg_handler.storage_set_id = 1
+        self.service_msg_handler.host_id = 1
+
+    def test_create_actuator_response(self):
+        msg = self.service_msg_handler._create_actuator_response(self.service_info)
+        assert msg['host_id'] == 1
+        assert msg['instance_id'] == 'kafka'
+        assert msg['specific_info'][0]['service_name'] == 'kafka'

--- a/unittests/test_service_monitor.py
+++ b/unittests/test_service_monitor.py
@@ -51,12 +51,12 @@ class TestServiceMonitor(unittest.TestCase):
             "UnitFileState": "enabled"
         }
 
-        Conf.get = Mock(side_effect=self.mocked_conf)
         Interface.Get = Mock(side_effect=self.mocked_properties)
         SystemBus.get_object = Mock()
         Service.dump_to_cache = Mock()
         Service.cache_exists = Mock(return_value=False)
-        self.service_monitor = ServiceMonitor()
+        with patch("cortx.utils.conf_store.Conf.get", new=Mock(side_effect=self.mocked_conf)):
+            self.service_monitor = ServiceMonitor()
         self.service_monitor._write_internal_msgQ = Mock()
         self.service_monitor.is_running = Mock(return_value=True)
         time.sleep = Mock(side_effect=self.terminate_run)


### PR DESCRIPTION
## Problem Statement
unittest base framework required for SSPL.

## Solution
pytest a popular third party library that is used for unittest.
* it is compatible with python's standard unittest library. So no extra learning curve for beginners.
* It is easier to set python paths via config.
* It is easier to specify multiple test directories via config.
* pytest fixtures are very useful in creating reusable test data (https://docs.pytest.org/en/6.2.x/fixture.html#fixtures)
* It is widely used among open source projects.

## Unit/Manual Testing Description
cd to the SSPL root directory and run the command
`pytest`

output:
```
→ pytest
......                                                                                                 [100%]
6 passed in 1.11s
```
