### PR TITLE
EOS:20886: No fault alerts seen in Kafka for CPU, diskspace and host_…

### DIFF
--- a/low-level/files/opt/seagate/sspl/conf/sspl.conf.LR2.yaml
+++ b/low-level/files/opt/seagate/sspl/conf/sspl.conf.LR2.yaml
@@ -71,8 +71,8 @@ LOGGINGMSGHANDLER:
 
 NODEDATAMSGHANDLER:
    transmit_interval: 10
-   high_cpu_usage_wait_threshold: 30
-   high_memory_usage_wait_threshold: 30
+   high_cpu_usage_wait_threshold: 10
+   high_memory_usage_wait_threshold: 20
    units: MB
    disk_usage_threshold: 80
    cpu_usage_threshold: 80

--- a/low-level/files/opt/seagate/sspl/conf/sspl.conf.LR2.yaml
+++ b/low-level/files/opt/seagate/sspl/conf/sspl.conf.LR2.yaml
@@ -71,8 +71,8 @@ LOGGINGMSGHANDLER:
 
 NODEDATAMSGHANDLER:
    transmit_interval: 10
-   high_cpu_usage_wait_threshold: 10
-   high_memory_usage_wait_threshold: 20
+   high_cpu_usage_wait_threshold: 30
+   high_memory_usage_wait_threshold: 30
    units: MB
    disk_usage_threshold: 80
    cpu_usage_threshold: 80

--- a/low-level/files/opt/seagate/sspl/setup/sspl_test.py
+++ b/low-level/files/opt/seagate/sspl/setup/sspl_test.py
@@ -150,6 +150,22 @@ class SSPLTestCmd:
                 threshold_inactive_time_new)
             Conf.save(SSPL_CONFIG_INDEX)
 
+            cpu_usage_alert_wait = Conf.get(SSPL_CONFIG_INDEX,
+                "NODEDATAMSGHANDLER>high_cpu_usage_wait_threshold")
+            memory_usage_alert_wait = Conf.get(SSPL_CONFIG_INDEX,
+                "NODEDATAMSGHANDLER>high_memory_usage_wait_threshold")
+
+            cpu_usage_alert_wait_new = 10
+            memory_usage_alert_wait_new = 20
+
+            Conf.set(SSPL_CONFIG_INDEX,
+                     "NODEDATAMSGHANDLER>high_cpu_usage_wait_threshold",
+                     cpu_usage_alert_wait_new)
+            Conf.set(SSPL_CONFIG_INDEX,
+                     "NODEDATAMSGHANDLER>high_memory_usage_wait_threshold",
+                      memory_usage_alert_wait_new)
+            Conf.save(SSPL_CONFIG_INDEX)
+
             # TODO: Convert shell script to python
             # from cortx.sspl.sspl_test.run_qa_test import RunQATest
             # RunQATest(self.plan, self.coverage_enabled).run()
@@ -168,8 +184,15 @@ class SSPLTestCmd:
                 service_list)
             Conf.set(SSPL_CONFIG_INDEX, "SERVICEMONITOR>threshold_inactive_time",
                 threshold_inactive_time_original)
-            Conf.set(SSPL_CONFIG_INDEX, "SYSTEM_INFORMATION>global_config_copy_url",
-                sspl_global_config_url)
+            Conf.set(SSPL_CONFIG_INDEX,
+                     "SYSTEM_INFORMATION>global_config_copy_url",
+                     sspl_global_config_url)
+            Conf.set(SSPL_CONFIG_INDEX,
+                     "NODEDATAMSGHANDLER>high_cpu_usage_wait_threshold",
+                     cpu_usage_alert_wait)
+            Conf.set(SSPL_CONFIG_INDEX,
+                     "NODEDATAMSGHANDLER>high_memory_usage_wait_threshold",
+                     memory_usage_alert_wait)
             Conf.save(SSPL_CONFIG_INDEX)
             shutil.copyfile(sspl_test_backup, sspl_test_file_path)
             if rc != 0:


### PR DESCRIPTION
…memory usage

<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

No fault alerts seen in Kafka for CPU, diskspace and host_memory usage

## Solution Design:
Reduced the wait threshold time for cpu, memory sensors so the alerts can be received in that time limit.

## Coding:

* [ ] Did you follow coding standard and verified it with flake8? 
yes
* [ ] Did your address all Codacy issues?
yes

## Testing:

* [ ] Unittest updated and all unittests are passing?
No test-case updation required for a fix.

* [ ] Sanity/Self tests are updated (if applicable)?
no

* [ ] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [ ] Did you add Jira number to the PR?
yes

* [ ] DCO and cla-signed?
yes
