### PR TITLE
EOS-20921: Add StreamHandler Logger to get logs on the console

### DIFF
--- a/low-level/files/opt/seagate/sspl/setup/setup_logger.py
+++ b/low-level/files/opt/seagate/sspl/setup/setup_logger.py
@@ -18,11 +18,12 @@
 # ****************************************************************************
 
 import logging
+import sys
 
 logger_facility = "sspl-setup"
 _logger = logging.getLogger(logger_facility)
 
-def init_logging(syslog_host="localhost", syslog_port=514):
+def init_logging(syslog_host="localhost", syslog_port=514, console_output=False):
     """Initialize logging for sspl-setup."""
     _logger.setLevel(logging.INFO)
     # set Logging Handlers
@@ -32,7 +33,10 @@ def init_logging(syslog_host="localhost", syslog_port=514):
                     "%(levelname)s %(message)s (%(filename)s:%(lineno)d)"
     formatter = logging.Formatter(syslog_format)
     handler.setFormatter(formatter)
-    if not len(_logger.handlers):
-        _logger.addHandler(handler)
+    _logger.addHandler(handler)
+    if console_output:
+        console = logging.StreamHandler(sys.stderr)
+        console.setFormatter(formatter)
+        _logger.addHandler(console)
 
 logger = _logger

--- a/low-level/files/opt/seagate/sspl/setup/sspl_setup.py
+++ b/low-level/files/opt/seagate/sspl/setup/sspl_setup.py
@@ -524,7 +524,7 @@ class RestoreCmd(Cmd):
 
 def main(argv: dict):
     try:
-        init_logging()
+        init_logging(console_output=True)
         desc = "SSPL Setup Interface"
         command = Cmd.get_command(desc, argv[1:])
         if not command:


### PR DESCRIPTION
<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

SSPL: Setup log is not created and error info lost during post_install failure

## Solution Design:

The Bug is non reproducible. Error Logs are getting generated.
Adding StreamHandler Logger to get the console output as well.

## Coding:

* [ ] Did you follow coding standard and verified it with flake8? 
yes
* [ ] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [ ] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [ ] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [ ] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [ ] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [ ] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
