### PR TITLE
EOS-21241 : SMS2-Build 631-Support bundle generation failed for sspl

### DIFF
--- a/low-level/files/opt/seagate/sspl/bin/generate_sspl_bundle/sspl_bundle_generate
+++ b/low-level/files/opt/seagate/sspl/bin/generate_sspl_bundle/sspl_bundle_generate
@@ -23,6 +23,7 @@ import sys
 import shutil
 import json
 import subprocess
+import psutil
 
 from framework.base.sspl_constants import (PRODUCT_FAMILY, SUPPORT_REQUESTOR_NAME,
     SUPPORT_EMAIL_ID, SUPPORT_CONTACT_NUMBER, ENCL_TRIGGER_LOG_MAX_RETRY,
@@ -32,7 +33,7 @@ from framework.base.sspl_constants import (PRODUCT_FAMILY, SUPPORT_REQUESTOR_NAM
 sys.path.insert(0, f'/opt/seagate/{PRODUCT_FAMILY}/sspl/low-level')
 from framework.utils.config_reader import ConfigReader
 onGoingRequestPath = f"{DATA_PATH}sspl-sb-req.txt"
-sspl_bundle_tmp = f"{DATA_PATH}sspl_bundle_{str(int(time.time()))}"
+sspl_bundle_tmp = f"{DATA_PATH}sspl_bundle_tmp"
 
 class SSPLBundleGenerate(object):
 
@@ -70,7 +71,7 @@ class SSPLBundleGenerate(object):
             "Lists all users": "rabbitmqctl list_users"
         }
 
-    def generate_sspl_support_bundle(self, parser, tmpFile):
+    def generate_sspl_support_bundle(self, parser):
         file_name = "sspl_%s.tar.gz" % parser[1]
         try:
             conf_reader = ConfigReader()
@@ -95,7 +96,6 @@ class SSPLBundleGenerate(object):
                 self.localTempPath = configure_path+"sspl/"
             else:
                 print("Given path doesn't exist")
-                tmpFile.close()
                 sspl_bundle_cleanup()
                 sys.exit(1)
         if not os.path.exists(self.localTempPath):
@@ -160,7 +160,6 @@ class SSPLBundleGenerate(object):
 
         except (OSError, tarfile.TarError) as err:
             print("Facing problem while creating sspl support bundle : %s" % err)
-            tmpFile.close()
             sspl_bundle_cleanup()
             sys.exit(1)
 
@@ -325,22 +324,37 @@ def sspl_bundle_cleanup():
     if os.path.exists(sspl_bundle_tmp):
         shutil.rmtree(sspl_bundle_tmp)
 
+def validate_sb_request():
+    """Checking previous process pid/request is running or not."""
+    allow_new_request = True
+    sb_pid = None
+    if os.path.isfile(onGoingRequestPath):
+        with open(onGoingRequestPath, 'r') as f:
+            sb_pid = f.read()
+        if sb_pid and psutil.pid_exists(int(sb_pid)):
+            allow_new_request = False
+        else:
+            sspl_bundle_cleanup()
+    return allow_new_request
+
 if __name__ == "__main__":
-    if not os.path.isfile(onGoingRequestPath):
-        if len(sys.argv) < 3:
-            print("Unrecognized arguments: %s" % sys.argv)
-            sys.exit(1)
-        tmpFile = open(onGoingRequestPath, "w")
+    if len(sys.argv) < 3:
+        sys.stderr.write("error: invalid argument %s" % sys.argv)
+        sys.exit(1)
+    allow_new_request = validate_sb_request()
+    if allow_new_request:
+        with open(onGoingRequestPath, 'w') as f:
+            f.write(str(os.getpid()))
         os.makedirs(sspl_bundle_tmp)
         try:
             SSPLBundleObj = SSPLBundleGenerate()
-            SSPLBundleObj.generate_sspl_support_bundle(sys.argv, tmpFile)
+            SSPLBundleObj.generate_sspl_support_bundle(sys.argv)
+            sspl_bundle_cleanup()
+            sys.exit(0)
         except Exception as e:
-            print("SSPL support bundle script is failed with an unexpected "
-                "error. please try again ..!")
-            print("Error Message : %s" % e)
-        tmpFile.close()
-        sspl_bundle_cleanup()
+            sys.stderr.write("Error occurred while creating support bundle. %s" % e)
+            sspl_bundle_cleanup()
+            sys.exit(1)
     else:
-        print("Already SSPL Support Bundle request is going on, So skipping current request..!")
+        sys.stderr.write("SSPL Support Bundle creation in progress. Existing...")
         sys.exit(1)


### PR DESCRIPTION
Signed-off-by: Satish Darade <satish.darade@seagate.com>

<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

Support bundle cache is not deleted due to someone has forcefully stopped/deleted support bundle service or restarted the system in between. That's why the new request is declined for the SSPL support bundle. because it is assuming that the old request is already going on on the basis of the existing cache.
​if we do for the fresh system. that error will not come.
​after completion of the support bundle request, all those files have been deleted automatically by the SSPL support bundle script.

## Solution Design:

## Coding:

* [x] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [x] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [x] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [x] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [x] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
