### PR TITLE
EOS-21171: Node down IEM/Alert is lost in SSPL.

### DIFF
--- a/low-level/framework/messaging/egress_accumulated_msgs_processor.py
+++ b/low-level/framework/messaging/egress_accumulated_msgs_processor.py
@@ -111,6 +111,8 @@ class EgressAccumulatedMsgsProcessor(ScheduledModuleThread, InternalMsgQ):
                 logger.debug("Found accumulated messages, trying to send again")
                 while not self.store_queue.is_empty():
                     message = self.store_queue.get()
+                    if isinstance(message, bytes):
+                        message = message.decode()
                     dict_msg = json.loads(message)
                     if "actuator_response_type" in dict_msg["message"]:
                         event_time = dict_msg["message"] \

--- a/low-level/framework/utils/filestore.py
+++ b/low-level/framework/utils/filestore.py
@@ -66,6 +66,8 @@ class FileStore(Store):
             if pickled:
                 pickle.dump(value, fh)
             else:
+                if isinstance(value, str):
+                    value = value.encode('utf-8')
                 fh.write(value)
 
         except IOError as err:


### PR DESCRIPTION
Signed-off-by: Shriya Deshmukh <shriya.deshmukh@seagate.com>

<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

<!--- Describe the problem this patch intends to solve. -->
Node down IEM/Alert is lost in SSPL.

## Solution Design:

<!-- For Bug and minor feature, describe the design changes here. 
For major feature, post the link to the solution page on the confluence Monitor team's space  -->
1. We were getting below the errors while  reading/flushing msgs from accumulated queue. 
 **'WARNING Error[a bytes-like object is required, not 'str'] while dumping data to file /var/cortx/sspl/data/SSPL_UNSENT_MESSAGES/MESSAGES/2 '**

**Expecting value: line 1 column 1 (char 0)**
Cause of error:  we open file in byte mode (wb) and trying to add string type value into flle.


## Coding:

* [x] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [x] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [ ] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [ ] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [ ] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
