### PR TITLE
EOS-21975 Removed haproxy, and hare-consul-agaentc1/c2 from external services monitoring list.

### DIFF
--- a/low-level/files/opt/seagate/sspl/conf/sspl.conf.LR2.yaml
+++ b/low-level/files/opt/seagate/sspl/conf/sspl.conf.LR2.yaml
@@ -145,13 +145,10 @@ SERVICEMONITOR:
    threshold_inactive_time: 180
    monitored_services:
       - hare-consul-agent.service
-      - hare-consul-agent-c1.service
-      - hare-consul-agent-c2.service
       - elasticsearch.service
       - multipathd.service
       - statsd.service
       - rsyslog.service
-      - haproxy.service
       - slapd.service
       - lnet.service
       - salt-master.service


### PR DESCRIPTION
Signed-off-by: Sumedh A. Kulkarni <sumedh.a.kulkarni@seagate.com>

<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:
Removed old hare consul services from monitoring list along with haporxy service monitoring since it is not in sspl monitoring scope.
<!--- Describe the problem this patch intends to solve. -->

## Solution Design:

<!-- For Bug and minor feature, describe the design changes here. 
For major feature, post the link to the solution page on the confluence Monitor team's space  -->

## Coding:

* [x] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [x] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [x] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [x] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [x] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [ ] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
