### PR TITLE
EOS-22214: Fix adaptive config

### DIFF
--- a/low-level/files/opt/seagate/sspl/conf/sspl.conf.LR2.yaml
+++ b/low-level/files/opt/seagate/sspl/conf/sspl.conf.LR2.yaml
@@ -192,6 +192,7 @@ SYSTEM_INFORMATION:
    environment: PROD
    sysfs_base_path: /sys/
    sspl_state: active
+   global_config_copy_url: ""
 
 # NOTE: Keys present in OBSOLETE section are out of date
 # and will be removed in furture version. Keys present in


### PR DESCRIPTION
<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->
Jira :[ EOS-22214](https://jts.seagate.com/browse/EOS-22214)
## Problem Statement:
global_config_copy_url was not present in default config file. So, conf_upgrade script treated that as removed key and hence it was not added into existing config file. SSPL service failed because of this
<!--- Describe the problem this patch intends to solve. -->

## Solution Design:

Add global_config_copy_url in default config file with "" value

<!-- For Bug and minor feature, describe the design changes here. 
For major feature, post the link to the solution page on the confluence Monitor team's space  -->

## Coding:

* [x] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [x] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [x] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [x] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [x] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
