### PR TITLE
EOS-21004: Introduce waiting time for CPU and memory usage fault resolved alert

### DIFF
--- a/low-level/message_handlers/node_data_msg_handler.py
+++ b/low-level/message_handlers/node_data_msg_handler.py
@@ -458,7 +458,8 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
         else:
             fault_resolved_iters = 0
         try:
-            iteration_limit = int(self._high_memory_usage_wait_threshold/self._transmit_interval)
+            iteration_limit = int(
+                self._high_memory_usage_wait_threshold/self._transmit_interval)
         except ZeroDivisionError:
             iteration_limit = 0
         self.usage_time_map['memory'] = current_time

--- a/low-level/message_handlers/node_data_msg_handler.py
+++ b/low-level/message_handlers/node_data_msg_handler.py
@@ -87,6 +87,11 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
         'memory' : -1,
         'disk' : -1
     }
+    fault_resolved_iterations = {
+        'cpu': 0,
+        'memory': 0,
+        'disk': 0
+    }
     prev_nw_status = {}
     prev_cable_cnxns = {}
     # Dir to maintain fault detected state for interface
@@ -132,7 +137,7 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
         super(NodeDataMsgHandler, self).initialize_msgQ(msgQlist)
 
         self._transmit_interval = int(Conf.get(SSPL_CONF, f"{self.NODEDATAMSGHANDLER}>{self.TRANSMIT_INTERVAL}",
-                                                60))
+                                               60))
         self._high_cpu_usage_wait_threshold = int(Conf.get(SSPL_CONF,
                                                 f"{self.NODEDATAMSGHANDLER}>{self.HIGH_CPU_USAGE_WAIT_THRESHOLD}",60))
         self._high_memory_usage_wait_threshold = int(Conf.get(SSPL_CONF,
@@ -231,8 +236,11 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
             }
         else:
             self.persistent_data[resource] = {
-                f'high_{resource}_usage' : str(self.high_usage[resource]),
-                f'{resource}_usage_time_map' : str(self.usage_time_map[resource])
+                f'high_{resource}_usage': str(self.high_usage[resource]),
+                f'{resource}_usage_time_map':
+                    str(self.usage_time_map[resource]),
+                f'{resource}_fault_resolved_iterations':
+                    str(self.fault_resolved_iterations[resource])
             }
         store.put(self.persistent_data[resource], PER_DATA_PATH)
 
@@ -443,6 +451,16 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
             previous_check_time = int(memory_persistent_data['memory_usage_time_map'])
         else:
             previous_check_time = int(-1)
+        if memory_persistent_data\
+                .get('memory_fault_resolved_iterations') is not None:
+            fault_resolved_iters = int(
+                memory_persistent_data['memory_fault_resolved_iterations'])
+        else:
+            fault_resolved_iters = 0
+        try:
+            iteration_limit = int(self._high_memory_usage_wait_threshold/self._transmit_interval)
+        except ZeroDivisionError:
+            iteration_limit = 0
         self.usage_time_map['memory'] = current_time
 
         if self._node_sensor.total_memory["percent"] >= self._host_memory_usage_threshold \
@@ -489,7 +507,11 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
             if not self.high_usage['memory']:
                 self.persist_state_data('memory', 'MEMORY_USAGE_DATA')
             else:
-                if self.usage_time_map['memory'] - previous_check_time >= self._high_memory_usage_wait_threshold:
+                if fault_resolved_iters < iteration_limit:
+                    fault_resolved_iters += 1
+                    self.fault_resolved_iterations['memory'] = fault_resolved_iters
+                    self.persist_state_data('memory', 'MEMORY_USAGE_DATA')
+                elif fault_resolved_iters >= iteration_limit:
                     # Create the memory data message and hand it over to the egress processor to transmit
                     fault_resolved_event = "Host memory usage decreased to %s, lesser than configured threshold of %s" \
                                             %(self._node_sensor.total_memory["percent"],
@@ -521,6 +543,7 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
                     self._write_internal_msgQ(EgressProcessor.name(), jsonMsg)
                     self.high_usage['memory'] = False
                     self.usage_time_map['memory'] = int(-1)
+                    self.fault_resolved_iterations['memory'] = 0
                     self.persist_state_data('memory', 'MEMORY_USAGE_DATA')
 
     def _generate_local_mount_data(self):
@@ -577,6 +600,16 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
             previous_check_time = int(cpu_persistent_data['cpu_usage_time_map'])
         else:
             previous_check_time = int(-1)
+        if cpu_persistent_data.get('cpu_fault_resolved_iterations') is not None:
+            fault_resolved_iters = int(
+                cpu_persistent_data['cpu_fault_resolved_iterations'])
+        else:
+            fault_resolved_iters = 0
+        try:
+            iteration_limit = int(
+                self._high_cpu_usage_wait_threshold/self._transmit_interval)
+        except ZeroDivisionError:
+            iteration_limit = 0
         self.usage_time_map['cpu'] = current_time
 
         if self._node_sensor.cpu_usage >= self._cpu_usage_threshold \
@@ -588,7 +621,6 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
             if self.usage_time_map['cpu'] - previous_check_time >= self._high_cpu_usage_wait_threshold:
 
                 self.high_usage['cpu'] = True
-
                 # Create the cpu usage data message and hand it over to the egress processor to transmit
                 fault_event = "CPU usage increased to %s, beyond configured threshold of %s for more than %s seconds" \
                                 %(self._node_sensor.cpu_usage, self._cpu_usage_threshold,
@@ -629,7 +661,12 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
             if not self.high_usage['cpu']:
                 self.persist_state_data('cpu', 'CPU_USAGE_DATA')
             else:
-                if self.usage_time_map['cpu'] - previous_check_time >= self._high_cpu_usage_wait_threshold:
+                if fault_resolved_iters < iteration_limit:
+                    fault_resolved_iters += 1
+                    self.fault_resolved_iterations['cpu'] = fault_resolved_iters
+                    self.persist_state_data('cpu', 'CPU_USAGE_DATA')
+                elif fault_resolved_iters >= iteration_limit:
+                
                     # Create the cpu usage data message and hand it over to the egress processor to transmit
                     fault_resolved_event = "CPU usage decreased to %s, lesser than configured threshold of %s" \
                         %(self._node_sensor.cpu_usage, self._cpu_usage_threshold)
@@ -664,6 +701,7 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
                     self._write_internal_msgQ(EgressProcessor.name(), jsonMsg)
                     self.high_usage['cpu'] = False
                     self.usage_time_map['cpu'] = int(-1)
+                    self.fault_resolved_iterations['cpu'] = 0
                     # Store the state to Persistent Cache.
                     self.persist_state_data('cpu', 'CPU_USAGE_DATA')
 

--- a/low-level/message_handlers/node_data_msg_handler.py
+++ b/low-level/message_handlers/node_data_msg_handler.py
@@ -666,7 +666,7 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
                     self.fault_resolved_iterations['cpu'] = fault_resolved_iters
                     self.persist_state_data('cpu', 'CPU_USAGE_DATA')
                 elif fault_resolved_iters >= iteration_limit:
-                
+
                     # Create the cpu usage data message and hand it over to the egress processor to transmit
                     fault_resolved_event = "CPU usage decreased to %s, lesser than configured threshold of %s" \
                         %(self._node_sensor.cpu_usage, self._cpu_usage_threshold)

--- a/low-level/message_handlers/node_data_msg_handler.py
+++ b/low-level/message_handlers/node_data_msg_handler.py
@@ -471,7 +471,7 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
 
             if self.usage_time_map['memory'] - previous_check_time >= self._high_memory_usage_wait_threshold:
                 self.high_usage['memory'] = True
-
+                self.fault_resolved_iterations['memory'] = 0
                 # Create the memory data message and hand it over
                 # to the egress processor to transmit
                 fault_event = "Host memory usage has increased to {}%,"\
@@ -629,6 +629,7 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
             if self.usage_time_map['cpu'] - previous_check_time >= self._high_cpu_usage_wait_threshold:
 
                 self.high_usage['cpu'] = True
+                self.fault_resolved_iterations['cpu'] = 0
                 # Create the cpu usage data message and hand it over
                 # to the egress processor to transmit
                 fault_event = "CPU usage has increased to {}%, "\

--- a/low-level/message_handlers/node_data_msg_handler.py
+++ b/low-level/message_handlers/node_data_msg_handler.py
@@ -525,7 +525,7 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
                             self._node_sensor.total_memory["percent"],
                             self._host_memory_usage_threshold
                         )
-                    logger.warning(fault_resolved_event)
+                    logger.info(fault_resolved_event)
                     logged_in_users = []
 
                     # Create the host update message and hand it over to the egress processor to transmit
@@ -689,7 +689,7 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
                             self._node_sensor.cpu_usage,
                             self._cpu_usage_threshold
                         )
-                    logger.warning(fault_resolved_event)
+                    logger.info(fault_resolved_event)
 
                     # Create the cpu usage update message and hand it over to the egress processor to transmit
                     cpuDataMsg = CPUdataMsg(self._node_sensor.host_id,
@@ -949,7 +949,7 @@ class NodeDataMsgHandler(ScheduledModuleThread, InternalMsgQ):
                     self._node_sensor.disk_used_percentage,
                     self._disk_usage_threshold
                 )
-            logger.warning(fault_resolved_event)
+            logger.info(fault_resolved_event)
             diskSpaceAlertMsg = DiskSpaceAlertMsg(self._node_sensor.host_id,
                                     self._epoch_time,
                                     self._node_sensor.total_space,


### PR DESCRIPTION
<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

Fault resolved alert for CPU/memory usage should wait for certain waiting threshold time.

## Solution Design:

Introduced waiting time for CPU/memory usage fault resolved alerts.

## Coding:

* [x] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [x] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [x] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [x] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [x] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
