### PR TITLE
EOS-19805: Add mini provisioner upgrade interface

### DIFF
--- a/low-level/files/opt/seagate/sspl/setup/sspl_setup.py
+++ b/low-level/files/opt/seagate/sspl/setup/sspl_setup.py
@@ -542,7 +542,7 @@ class RestoreCmd(Cmd):
 
 
 class PreUpgradeCmd(Cmd):
-    """PreUpgrade support for SSPL componenet."""
+    """PreUpgrade support for SSPL component."""
 
     name = "pre_upgrade"
 
@@ -554,7 +554,7 @@ class PreUpgradeCmd(Cmd):
         pass
 
     def process(self):
-        logger.info(f"{self.name} interface not implemented.")
+        logger.info(f"Nothing to be done for {self.name}.")
 
 
 class PostUpgradeCmd(Cmd):
@@ -576,15 +576,14 @@ class PostUpgradeCmd(Cmd):
         # Only proceed if both existing and new config path are present
         for filepath in [existing_conf_url, new_conf_url]:
             if not os.path.exists(filepath.split(":/")[1]):
-                logger.info("Exiting, File %s does not exists" % filepath)
+                logger.debug("Config not upgraded as existing or new config file is not present.")
                 return
         conf_upgrade = ConfUpgrade(existing_conf_url, new_conf_url,
                                    merged_conf_url)
         try:
             conf_upgrade.create_merged_config()
         except ConfError as e:
-            logger.error("Error: %s while upgrading config file, existing config"
-                         "file is retained" % e)
+            logger.error("%s error seen while upgrading config, existing config retained" % e)
         else:
             conf_upgrade.upgrade_existing_config()
         finally:

--- a/low-level/files/opt/seagate/sspl/setup/sspl_setup.py
+++ b/low-level/files/opt/seagate/sspl/setup/sspl_setup.py
@@ -541,10 +541,26 @@ class RestoreCmd(Cmd):
         logger.info(f"{self.name} interface not implemented.")
 
 
-class UpgradeCmd(Cmd):
-    """Upgrade support for SSPL componenet."""
+class PreUpgradeCmd(Cmd):
+    """PreUpgrade support for SSPL componenet."""
 
-    name = "upgrade"
+    name = "pre_upgrade"
+
+    def __init__(self, args):
+        super().__init__(args)
+
+    def validate(self):
+        # Common validator classes to check Cortx/system wide validator
+        pass
+
+    def process(self):
+        logger.info(f"{self.name} interface not implemented.")
+
+
+class PostUpgradeCmd(Cmd):
+    """PostUpgrade support for SSPL componenet."""
+
+    name = "post_upgrade"
 
     def __init__(self, args):
         super().__init__(args)

--- a/low-level/files/opt/seagate/sspl/setup/sspl_setup.py
+++ b/low-level/files/opt/seagate/sspl/setup/sspl_setup.py
@@ -39,7 +39,8 @@ from files.opt.seagate.sspl.setup.setup_error import SetupError
 from files.opt.seagate.sspl.setup.setup_logger import init_logging, logger
 from framework.base.sspl_constants import (
     PRVSNR_CONFIG_INDEX, GLOBAL_CONFIG_INDEX, global_config_path,
-    file_store_config_path, SSPL_BASE_DIR, TEST_REQ_SERVICE_RESTART)
+    file_store_config_path, SSPL_BASE_DIR, TEST_REQ_SERVICE_RESTART,
+    sspl_config_path)
 from framework.base.conf_upgrade import ConfUpgrade
 
 
@@ -571,14 +572,13 @@ class PostUpgradeCmd(Cmd):
 
     def process(self):
         new_conf_url = 'yaml:///opt/seagate/cortx/sspl/conf/sspl.conf.LR2.yaml'
-        existing_conf_url = 'yaml:///etc/sspl.conf'
         merged_conf_url = 'yaml:///opt/seagate/cortx/sspl/tmp/merged.conf'
         # Only proceed if both existing and new config path are present
-        for filepath in [existing_conf_url, new_conf_url]:
+        for filepath in [sspl_config_path, new_conf_url]:
             if not os.path.exists(filepath.split(":/")[1]):
                 logger.debug("Config not upgraded as existing or new config file is not present.")
                 return
-        conf_upgrade = ConfUpgrade(existing_conf_url, new_conf_url,
+        conf_upgrade = ConfUpgrade(sspl_config_path, new_conf_url,
                                    merged_conf_url)
         try:
             conf_upgrade.create_merged_config()

--- a/low-level/framework/base/conf_upgrade.py
+++ b/low-level/framework/base/conf_upgrade.py
@@ -13,12 +13,10 @@
 # about this software or licensing, please email opensource@seagate.com or
 # cortx-questions@seagate.com.
 
-import sys
 import os
 import shutil
 
 from cortx.utils.conf_store import Conf
-from cortx.utils.conf_store.error import ConfError
 from cortx.utils.kv_store.kv_payload import KvPayload
 
 
@@ -91,25 +89,3 @@ class ConfUpgrade:
         """Remove tmp files created for merging config."""
         os.remove(self.merged_path)
         os.removedirs(self.merged_path_dir)
-
-
-if __name__ == "__main__":
-    new_conf_url = 'yaml:///opt/seagate/cortx/sspl/conf/sspl.conf.LR2.yaml'
-    existing_conf_url = 'yaml:///etc/sspl.conf'
-    merged_conf_url = 'yaml:///opt/seagate/cortx/sspl/tmp/merged.conf'
-    # Only proceed if both existing and new config path are present
-    for filepath in [existing_conf_url, new_conf_url]:
-        if not os.path.exists(filepath.split(":/")[1]):
-            print("Exiting, File %s does not exists" % filepath)
-            sys.exit(0)
-    conf_upgrade = ConfUpgrade(existing_conf_url, new_conf_url,
-                               merged_conf_url)
-    try:
-        conf_upgrade.create_merged_config()
-    except ConfError as e:
-        print("Error: %s while upgrading config file, existing config"
-              "file is retained" % e)
-    else:
-        conf_upgrade.upgrade_existing_config()
-    finally:
-        conf_upgrade.remove_merged_config()

--- a/low-level/sspl-ll.spec
+++ b/low-level/sspl-ll.spec
@@ -98,9 +98,6 @@ SSPL_DIR=/opt/seagate/%{product_family}/sspl
     ln -sf $SSPL_DIR/low-level/solution $SSPL_DIR/bin/solution
 }
 
-# upgrade conf
-[ -f $SSPL_DIR/low-level/framework/base/conf_upgrade.py ] && python3 $SSPL_DIR/low-level/framework/base/conf_upgrade.py
-
 # restore of data & iem folder
 [ -d /opt/seagate/%{product_family}/backup/%{version}/sspl ] &&
     cp -Rp /opt/seagate/%{product_family}/backup/%{version}/sspl/* /var/%{product_family}/sspl/
@@ -111,12 +108,6 @@ SSPL_DIR=/opt/seagate/%{product_family}/sspl
 
 # [ -f /etc/rsyslog.d/1-ssplfwd.conf ] ||
 #    cp /opt/seagate/%{product_family}/sspl/low-level/files/etc/rsyslog.d/1-ssplfwd.conf /etc/rsyslog.d/1-ssplfwd.conf
-
-# In case of upgrade start sspl-ll after upgrade
-if [ "$1" == "2" ]; then
-    echo "Restarting sspl-ll service..."
-    systemctl restart sspl-ll.service 2> /dev/null
-fi
 
 if [ "$1" == "1" ]; then
     echo "Installation complete. Follow the instructions."


### PR DESCRIPTION
Jira: [EOS-19805](https://jts.seagate.com/browse/EOS-19805)
<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

Enabled non-disruptive sw upgrade through sspl mini-provisioner upgrade interface
- Currently configuration upgrade from rpm spec file. That needs to be done from upgrade interface

<!--- Describe the problem this patch intends to solve. -->

## Solution Design:
- Implement upgrade class in sspl_setup

<!-- For Bug and minor feature, describe the design changes here. 
For major feature, post the link to the solution page on the confluence Monitor team's space  -->

## Coding:

* [x] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [ ] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [x] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [ ] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [x] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
