### PR TITLE
EOS-21171:Node down IEM/Alert is lost in SSPL

### DIFF
--- a/low-level/framework/messaging/egress_accumulated_msgs_processor.py
+++ b/low-level/framework/messaging/egress_accumulated_msgs_processor.py
@@ -131,6 +131,7 @@ class EgressAccumulatedMsgsProcessor(ScheduledModuleThread, InternalMsgQ):
                     if isinstance(self._producer, MessageProducer):
                         self._producer.send([message])
                         logger.error(f"Published Accumulated Message {message}")
+                        self.store_queue.delete()
                     else:
                         self.create_MsgProducer_obj()
         except MessageBusError as e:

--- a/low-level/framework/messaging/egress_accumulated_msgs_processor.py
+++ b/low-level/framework/messaging/egress_accumulated_msgs_processor.py
@@ -130,7 +130,7 @@ class EgressAccumulatedMsgsProcessor(ScheduledModuleThread, InternalMsgQ):
                         logger.info(f"Publishing Accumulated Alert: {message}")
                     if isinstance(self._producer, MessageProducer):
                         self._producer.send([message])
-                        logger.error(f"Published Accumulated Message {message}")
+                        logger.info(f"Published Accumulated Message {message}")
                         self.store_queue.delete()
                     else:
                         self.create_MsgProducer_obj()

--- a/low-level/framework/messaging/egress_processor.py
+++ b/low-level/framework/messaging/egress_processor.py
@@ -226,6 +226,9 @@ class EgressProcessor(ScheduledModuleThread, InternalMsgQ):
                             self._producer.send([jsonMsg])
                             logger.info(f"Published Alert: {jsonMsg}")
                         else:
+                            logger.info(f"MessageProducer instance is not available,"
+                                "adding message to accumulated queue.")
+                            self.store_queue.put(jsonMsg)
                             self.create_MsgProducer_obj()
                     else:
                         logger.info("'Accumulated msg queue' is not Empty." +

--- a/low-level/framework/utils/store_queue.py
+++ b/low-level/framework/utils/store_queue.py
@@ -102,10 +102,15 @@ class StoreQueue:
         if self.is_empty():
             return
         item = store.get(f"{self.SSPL_UNSENT_MESSAGES}/{self.head}")
+        return item
+
+    def delete(self):
+        if self.is_empty():
+            return
+        item = store.get(f"{self.SSPL_UNSENT_MESSAGES}/{self.head}")
         store.delete(f"{self.SSPL_UNSENT_MESSAGES}/{self.head}")
         self.head += 1
         self.current_size -= sys.getsizeof(item)
-        return item
 
     def put(self, item):
         size_of_item = sys.getsizeof(item)

--- a/sspl_test/messaging/ingress_processor_tests.py
+++ b/sspl_test/messaging/ingress_processor_tests.py
@@ -105,10 +105,17 @@ class IngressProcessorTests(ScheduledModuleThread, InternalMsgQ):
         self._read_config()
 
         producer_initialized.wait()
-        self._consumer = MessageConsumer(consumer_id=self._consumer_id,
+        self.create_MsgConsumer_obj()
+
+    def create_MsgConsumer_obj(self):
+        self._consumer = None
+        try:
+            self._consumer = MessageConsumer(consumer_id=self._consumer_id,
                                          consumer_group=self._consumer_group,
                                          message_types=[self._message_type],
                                          auto_ack=False, offset=self._offset)
+        except Exception as err:
+            logger.error('Instance creation for MessageConsumer class failed due to %s' % err)
 
     def run(self):
         # self._set_debug(True)
@@ -120,13 +127,20 @@ class IngressProcessorTests(ScheduledModuleThread, InternalMsgQ):
 
         try:
             while True:
-                message = self._consumer.receive()
+                message = None
+                if isinstance(self._consumer, MessageConsumer):
+                    message = self._consumer.receive()
+                else:
+                    self.create_MsgConsumer_obj()
                 if message:
                     logger.info(
                         f"IngressProcessorTests, Message Recieved: {message}")
                     self._process_msg(message)
                     # Acknowledge message was received
-                    self._consumer.ack()
+                    if isinstance(self._consumer, MessageConsumer):
+                        self._consumer.ack()
+                    else:
+                        self.create_MsgConsumer_obj()
                 else:
                     time.sleep(1)
         except Exception as e:


### PR DESCRIPTION
<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

<!--- Describe the problem this patch intends to solve. -->
Instance creation for MessageProducer class failed when kafka is down on all three nodes.


## Solution Design:

<!-- For Bug and minor feature, describe the design changes here. 
For major feature, post the link to the solution page on the confluence Monitor team's space  -->

## Coding:

* [ ] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [ ] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [ ] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [ ] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [ ] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
