### PR TITLE
EOS-22969: Fix raid health

### DIFF
--- a/low-level/framework/platforms/server/raid.py
+++ b/low-level/framework/platforms/server/raid.py
@@ -31,10 +31,7 @@ class RAID:
 
     def get_devices(self):
         output, err, returncode = SimpleProcess(f"mdadm --detail --test {self.raid}").run()
-        if returncode == 0:
-            output = output.decode()
-        else:
-            output = err.decode()
+        output = (output + err).decode()
         devices = []
         for state in re.findall(r"^\s*\d+\s*\d+\s*\d+\s*\d+\s*(.*)", output, re.MULTILINE):
             device = {}
@@ -60,7 +57,7 @@ class RAID:
         if returncode == 0:
             return ("OK", "The array is in good health")
         elif returncode == 2:
-            return ("Failed", "The array has multiple failed devices such that it is unusable.")
+            return ("Fault", "The array has multiple failed devices such that it is unusable.")
         elif returncode == 1:
             return ("Degraded", "The array has at least one failed device.")
         else:


### PR DESCRIPTION
Jira: [EOS-22969](https://jts.seagate.com/browse/EOS-22969)
<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:
Raid health filter for DEGRADED is not working

<!--- Describe the problem this patch intends to solve. -->

## Solution Design:
Changed Degraded/Fault to DEGRADED/FAULT

<!-- For Bug and minor feature, describe the design changes here. 
For major feature, post the link to the solution page on the confluence Monitor team's space  -->

## Coding:

* [ ] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [x] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [ ] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [ ] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [ ] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [ ] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [ ] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
