### PR TITLE
EOS-23002: Node Health - Set resource health status 'FAULT' if it is 'NA'  - Resource health status is coming as 'NA' for 'inactive' services and other resources (CPU, SAS_PORTS)

### DIFF
--- a/low-level/files/opt/seagate/sspl/setup/resource_map/lr2/resource_map.py
+++ b/low-level/files/opt/seagate/sspl/setup/resource_map/lr2/resource_map.py
@@ -88,6 +88,9 @@ class ResourceMap(metaclass=ABCMeta):
         if not recommendation:
             recommendation = 'NA' if good_state\
                 else DEFAULT_RECOMMENDATION
+        else:
+            if "No action is required" in recommendation.lower():
+                status = "OK"
         health_data["last_updated"] = int(time.time())
         health_data["health"].update({
             "status": status,

--- a/low-level/files/opt/seagate/sspl/setup/resource_map/lr2/server.py
+++ b/low-level/files/opt/seagate/sspl/setup/resource_map/lr2/server.py
@@ -250,8 +250,8 @@ class ServerMap(ResourceMap):
             uid = f"CPU-{cpu_id}"
             cpu_dict = self.get_health_template(uid, is_fru=False)
             online_status = "Online" if cpu_id in cpu_online else "Offline"
-            health_status = "OK" if online_status == "Online" else "NA"
-            usage = "NA" if health_status == "NA" \
+            health_status = "OK" if online_status == "Online" else "FAULT"
+            usage = "NA" if health_status == "FAULT" \
                 else cpu_usage_dict[cpu_id]
             specifics = [
                 {
@@ -318,7 +318,7 @@ class ServerMap(ResourceMap):
         upper_critical = sensor_props[1].get('Upper Critical', 'NA')
         lower_non_recoverable = sensor_props[1].get('Lower Non-Recoverable', 'NA')
         upper_non_recoverable = sensor_props[1].get('Upper Non-Recoverable', 'NA')
-        status = 'OK' if reading[2] == 'ok' else 'NA'
+        status = 'OK' if reading[2] == 'ok' else 'FAULT'
         health_desc = 'good' if status == 'OK' else 'bad'
         description = f"{uid} sensor is in {health_desc} health."
         recommendation = const.DEFAULT_RECOMMENDATION if status != 'OK' else 'NA'
@@ -535,7 +535,7 @@ class ServerMap(ResourceMap):
                 specifics['phys'].append(phy_data)
                 if not phy_data or phy_data['state'] != 'enabled' or \
                    'Gbit' not in phy_data['negotiated_linkrate']:
-                    health = "NA"
+                    health = "FAULT"
             self.set_health_data(port_data, health, specifics=[specifics])
             sas_ports_data.append(port_data)
         return sas_ports_data
@@ -571,7 +571,7 @@ class ServerMap(ResourceMap):
             # Map and set the interface health status and description.
             map_status = {"CONNECTED": "OK", "DISCONNECTED": "Disabled/Failed",
                           "UNKNOWN": "NA"}
-            health_status = map_status[nw_cable_conn_status]
+            health_status = "OK" if map_status[nw_cable_conn_status] == "OK" else "FAULT"
             desc = "Network Interface '%s' is %sin good health." % (
                 interface, '' if health_status == "OK" else 'not '
             )
@@ -642,7 +642,7 @@ class ServerMap(ResourceMap):
             const.UNIT_IFACE, 'UnitFileState') else False
         uid = str(properties_iface.Get(const.UNIT_IFACE, 'Id'))
         if not is_installed:
-            health_status = "NA"
+            health_status = "FAULT"
             health_description = f"Software enabling {uid} is not installed"
             recommendation = "NA"
             specifics = [
@@ -703,7 +703,7 @@ class ServerMap(ResourceMap):
                 health_description = f"{uid} is in good health"
                 recommendation = "NA"
             else:
-                health_status = state
+                health_status = 'FAULT'
                 health_description = f"{uid} is not in good health"
                 recommendation = const.DEFAULT_RECOMMENDATION
 

--- a/low-level/files/opt/seagate/sspl/setup/resource_map/lr2/storage.py
+++ b/low-level/files/opt/seagate/sspl/setup/resource_map/lr2/storage.py
@@ -145,7 +145,7 @@ class StorageMap(ResourceMap):
             "speed": fan.get("speed", "NA"),
             "serial-number": fan.get("serial-number", "N/A"),
             "part-number": fan.get("part-number", "N/A"),
-            "health": fan.get("health", "OK"),
+            "health": fan.get("health", "FAULT"),
         }
 
     def get_fanmodules_info(self):
@@ -200,7 +200,7 @@ class StorageMap(ResourceMap):
         enclosures = self.get_realstor_encl_data("enclosures")
         for encl in enclosures:
             uid = encl.get("durable-id")
-            status = encl.get("health", "NA")
+            status = encl.get("health", "FAULT")
             description = encl.get("description", "NA")
             recommendation = encl.get("health-recommendation", "NA")
             specifics = [{
@@ -227,7 +227,7 @@ class StorageMap(ResourceMap):
         controllers = self.get_realstor_encl_data("controllers")
         for controller in controllers:
             uid = controller.get("durable-id")
-            status = controller.get("health", "NA")
+            status = controller.get("health", "FAULT")
             description = controller.get("description")
             recommendation = controller.get("health-recommendation")
             specifics = [
@@ -256,7 +256,7 @@ class StorageMap(ResourceMap):
         psus = self.get_realstor_encl_data("power-supplies")
         for psu in psus:
             uid = psu.get("durable-id")
-            status = psu.get("health", "NA")
+            status = psu.get("health", "FAULT")
             description = psu.get("description")
             recommendation = psu.get("health-recommendation")
             specifics = [
@@ -333,7 +333,7 @@ class StorageMap(ResourceMap):
         if logicalvolumes:
             for logicalvolume in logicalvolumes:
                 uid = logicalvolume.get("volume-name", "NA")
-                health = logicalvolume.get("health", "NA")
+                health = logicalvolume.get("health", "FAULT")
                 if health in const.HEALTH_UNDESIRED_VALS:
                     health = "NA"
                 description = logicalvolume.get("volume-description", "NA")
@@ -378,7 +378,7 @@ class StorageMap(ResourceMap):
         if diskgroups:
             for diskgroup in diskgroups:
                 uid = diskgroup.get("name", "NA")
-                health = diskgroup.get("health", "NA")
+                health = diskgroup.get("health", "FAULT")
                 pool_sr_no = diskgroup.get("pool-serial-number", "NA")
                 if pool_sr_no in dg_vol_map:
                     volumes = dg_vol_map[pool_sr_no]
@@ -426,7 +426,7 @@ class StorageMap(ResourceMap):
             uid = sideplane.get("durable-id", "NA")
             expanders = sideplane.get("expanders")
             expander_data = self.get_expander_data(expanders)
-            health = sideplane.get("health", "NA")
+            health = sideplane.get("health", "FAULT")
             recommendation = sideplane.get("health-recommendation", "NA")
             specifics = [
                 {
@@ -451,7 +451,7 @@ class StorageMap(ResourceMap):
         expander_data = []
         for expander in expanders:
             uid = expander.get("durable-id", "NA")
-            expander_health = expander.get("health", "NA")
+            expander_health = expander.get("health", "FAULT")
             recommendation = expander.get("health-recommendation", "NA")
             specifics = [
                 {
@@ -477,7 +477,7 @@ class StorageMap(ResourceMap):
             if slot == -1:
                 continue
             uid = drive.get("durable-id")
-            status = drive.get("health", "NA")
+            status = drive.get("health", "FAULT")
             description = drive.get("description", "NA")
             recommendation = drive.get("health-recommendation", "NA")
             specifics = [
@@ -580,7 +580,7 @@ class StorageMap(ResourceMap):
                 "status": sas_port.get("status")
             }]
             self.set_health_data(
-                port_data, sas_port.get("health"),
+                port_data, sas_port.get("health", "FAULT"),
                 sas_port.get("health-reason"),
                 sas_port.get("health-recommendation"), specifics)
             data.append(port_data)


### PR DESCRIPTION
<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

Node Health - Resource health status is coming as 'NA' for 'inactive' services and other resources (CPU, SAS_PORTS)

## Solution Design:

Set resource health status 'FAULT' if it is 'NA'

## Coding:

* [x] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [x] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [x] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [x] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [x] Manual testing done covering happy path and non-happy path?

## Integration:

* [x] If there is any interface change, did you communicate it to other components?
* [x] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [x] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
