### PR TITLE
EOS-22560: Failed to restart rsyslog.service during post_install stage

### DIFF
--- a/low-level/files/opt/seagate/sspl/setup/sspl_post_install.py
+++ b/low-level/files/opt/seagate/sspl/setup/sspl_post_install.py
@@ -331,7 +331,7 @@ class SSPLPostInstall:
                 break
             except ServiceError as err:
                 if not attempt < 3:
-                    logger.critical("Restarting rsyslog.service is failed " \
+                    logger.critical("Restarting rsyslog.service failed " \
                         "due to error, %s" % err)
                     raise
                 logger.debug("Waiting for rsyslog service to become active..")


### PR DESCRIPTION
<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:
Failed to restart rsyslog.service during SSPL deployment - post_install stage
This is observed as an intermittent issue. When we rerun the same command the issue wont occur again.

## Solution Design:

Wait and retry restarting rsyslog.service

For major feature, post the link to the solution page on the confluence Monitor team's space  -->

## Coding:

* [x] Did you follow coding standard and verified it with flake8? Yes
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [x] Did your address all Codacy issues? Yes

<!-- Explain code changes here. -->

## Testing:

* [x] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [x] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [x] Manual testing done covering happy path and non-happy path?

## Integration:

* [x] If there is any interface change, did you communicate it to other components?
* [x] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [x] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
