### PR TITLE
EOS-17286: Need sanity test options to generate Alerts in GUI

### DIFF
--- a/low-level/files/opt/seagate/sspl/setup/sspl_setup.py
+++ b/low-level/files/opt/seagate/sspl/setup/sspl_setup.py
@@ -303,6 +303,8 @@ class TestCmd(Cmd):
                              help='Test plan type')
         parsers.add_argument('--coverage', action="store_true",
                              help='Boolean - Enable Code Coverage.')
+        parsers.add_argument('--alerts', action="store_true",
+                             help='Boolean - Enable alerts on CSM.')
         parsers.set_defaults(command=cls)
 
     def validate(self):

--- a/sspl_test/conf/sspl_tests.conf
+++ b/sspl_test/conf/sspl_tests.conf
@@ -4,12 +4,12 @@ SSPL-TESTS_SETTING:
       - EgressProcessorTests
 EGRESSPROCESSORTESTS:
    producer_id: sspl-sensor
-   message_type: requests
+   message_type: test-requests
    method: sync
 INGRESSPROCESSORTESTS:
    consumer_id: sspl_actuator
    consumer_group: cortx_monitor
-   message_type: alerts
+   message_type: test-alerts
    offset: latest
 RAIDSENSOR:
    monitor: true

--- a/sspl_test/framework/base/sspl_constants.py
+++ b/sspl_test/framework/base/sspl_constants.py
@@ -28,6 +28,10 @@ cs_legacy_products = ["CS-L", "CS-G"]
 RESOURCE_PATH = f"/opt/seagate/{PRODUCT_FAMILY}/sspl/low-level/json_msgs/schemas/"
 DATA_PATH = f"/var/{PRODUCT_FAMILY}/sspl/data/"
 IEM_DATA_PATH = "/var/%s/sspl/data/iem/sspl_iems"  %(PRODUCT_FAMILY)
+CONFIG_SPEC_TYPE = "yaml"
+SSPL_TEST_BKP_CONFIG = "SSPL_TEST_BACKUP"
+file_store_bkp_file = '/etc/sspl_tests.conf.back'
+sspl_test_bkp_config = "%s://%s" % (CONFIG_SPEC_TYPE, file_store_bkp_file)
 
 SSPL_STORE_TYPE = 'file'
 CONSUL_HOST = '127.0.0.1'

--- a/sspl_test/messaging/egress_processor_tests.py
+++ b/sspl_test/messaging/egress_processor_tests.py
@@ -71,7 +71,7 @@ class EgressProcessorTests(ScheduledModuleThread, InternalMsgQ):
         super(EgressProcessorTests, self).__init__(self.MODULE_NAME,
                                                       self.PRIORITY)
 
-    def initialize(self, conf_reader, msgQlist, product):
+    def initialize(self, conf_reader, msgQlist, product, alerts_on_csm):
         """initialize configuration reader and internal msg queues"""
         # Initialize ScheduledMonitorThread
         super(EgressProcessorTests, self).initialize(conf_reader)
@@ -147,7 +147,7 @@ class EgressProcessorTests(ScheduledModuleThread, InternalMsgQ):
                                          "sspl-sensor")
             self._message_type = Conf.get(SSPL_TEST_CONF,
                                           f"{self.PROCESSOR}>{self.MESSAGE_TYPE}",
-                                          "Alerts")
+                                          "test-requests")
             self._method = Conf.get(SSPL_TEST_CONF,
                                     f"{self.PROCESSOR}>{self.METHOD}",
                                     "Sync")

--- a/sspl_test/messaging/ingress_processor_tests.py
+++ b/sspl_test/messaging/ingress_processor_tests.py
@@ -27,7 +27,7 @@ import socket
 from jsonschema import Draft3Validator
 from jsonschema import validate
 
-from cortx.utils.message_bus import MessageConsumer
+from cortx.utils.message_bus import MessageConsumer, MessageProducer
 
 from framework.base.module_thread import ScheduledModuleThread
 from framework.base.internal_msgQ import InternalMsgQ

--- a/sspl_test/run_qa_test.sh
+++ b/sspl_test/run_qa_test.sh
@@ -36,6 +36,7 @@ while [ $# -gt 0 ]; do
             ;;
         --alerts )
             declare alerts_on_csm="$2"
+            ;;
         * ) ;;
     esac
     shift

--- a/sspl_test/run_qa_test.sh
+++ b/sspl_test/run_qa_test.sh
@@ -25,6 +25,7 @@ source $script_dir/constants.sh
 SSPL_STORE_TYPE=confstor
 
 coverage_enabled="False"
+alerts_on_csm="False"
 while [ $# -gt 0 ]; do
     case $1 in
         --plan )
@@ -33,6 +34,8 @@ while [ $# -gt 0 ]; do
         --coverage )
             declare coverage_enabled="$2"
             ;;
+        --alerts )
+            declare alerts_on_csm="$2"
         * ) ;;
     esac
     shift
@@ -175,7 +178,7 @@ trap cleanup 1 2 3 6 9 15
 
 execute_test()
 {
-    $sudo $script_dir/run_sspl-ll_tests.sh $plan
+    $sudo $script_dir/run_sspl-ll_tests.sh $plan $alerts_on_csm
 }
 
 if [ "$plan" == "sanity" ]

--- a/sspl_test/run_sspl-ll_tests.sh
+++ b/sspl_test/run_sspl-ll_tests.sh
@@ -20,6 +20,7 @@ script_dir=$(dirname $0)
 source "$script_dir"/constants.sh
 # Default test plan is sanity
 PLAN=${1:-dev_sanity}
+ALERTS=${2:-False}
 
 SRVNODE=""
 
@@ -52,4 +53,4 @@ fi
 systemctl start crond
 
 # Execute tests
-sudo /opt/seagate/"$PRODUCT_FAMILY"/sspl/sspl_test/run_test.py -t "$script_dir"/plans/"$PLAN".pln
+sudo /opt/seagate/"$PRODUCT_FAMILY"/sspl/sspl_test/run_test.py -t "$script_dir"/plans/"$PLAN".pln -a "$ALERTS"

--- a/sspl_test/run_test.py
+++ b/sspl_test/run_test.py
@@ -133,14 +133,16 @@ def tmain(argp, argv):
 if __name__ == '__main__':
     try:
         argParser = argparse.ArgumentParser(
-            usage = "%(prog)s [-h] [-t]",
+            usage = "%(prog)s [-h] [-t] [-a]",
             formatter_class = argparse.RawDescriptionHelpFormatter)
         argParser.add_argument("-t",
                 help="Enter path of testlist file")
+        argParser.add_argument("-a",
+                help="Boolean - Enable alerts on CSM.")
         args = argParser.parse_args()
 
         args = argParser.parse_args()
-        init_messaging_msg_processors()
+        init_messaging_msg_processors(args, sys.argv[0])
         tmain(args, sys.argv[0])
         generate_html_report(result)
         stop_messaging_msg_processors()


### PR DESCRIPTION
<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

 Need sanity test options to generate Alerts in GUI

## Solution Design:

Added support to generate alerts on CSM.
QA Framework will listen to local topics test-alerts & test-requests on MessageBus
And if alerts_on_csm flag is enabled, producer will send messages on alerts via MessageBus

## Coding:

* [ ] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [ ] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [ ] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [ ] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [ ] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
