### PR TITLE
EOS-22363:SSPL systemd resource start/stop timing requirements for HA

### DIFF
--- a/low-level/files/opt/seagate/sspl/conf/sspl-ll.service.LR2
+++ b/low-level/files/opt/seagate/sspl/conf/sspl-ll.service.LR2
@@ -29,6 +29,7 @@ PIDFile=/var/run/sspl_ll/sspl_ll.pid
 User=sspl-ll
 Restart=no
 TimeoutStartSec=190
+TimeoutStopSec=90
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

<!--- Describe the problem this patch intends to solve. -->

## Solution Design:

<!-- For Bug and minor feature, describe the design changes here. 
For major feature, post the link to the solution page on the confluence Monitor team's space  -->

## Coding:

* [ ] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [ ] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [ ] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [ ] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [ ] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [ ] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [ ] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
