### PR TITLE
EOS-23172: Description seen as 'N/A' for healthy Storage controller

### DIFF
--- a/low-level/framework/base/sspl_constants.py
+++ b/low-level/framework/base/sspl_constants.py
@@ -228,7 +228,7 @@ SSPL_CONFIGS = ['log_level', 'cli_type', 'sspl_log_file_path', 'cluster_id', 'st
 RESOURCE_MAP = {
     "server_type_supported": ["hw", "vm"],
     "storage_type_supported": ["rbod", "jbod", "ebod"],
-    "undesired_values": ["NA", "N/A", "", None]
+    "undesired_values": ["NA", "N/A", ""]
 }
 
 

--- a/low-level/framework/base/sspl_constants.py
+++ b/low-level/framework/base/sspl_constants.py
@@ -227,7 +227,8 @@ SSPL_CONFIGS = ['log_level', 'cli_type', 'sspl_log_file_path', 'cluster_id', 'st
 
 RESOURCE_MAP = {
     "server_type_supported": ["hw", "vm"],
-    "storage_type_supported": ["rbod", "jbod", "ebod"]
+    "storage_type_supported": ["rbod", "jbod", "ebod"],
+    "undesired_values": ["NA", "N/A", "", None]
 }
 
 

--- a/low-level/framework/base/sspl_constants.py
+++ b/low-level/framework/base/sspl_constants.py
@@ -227,8 +227,7 @@ SSPL_CONFIGS = ['log_level', 'cli_type', 'sspl_log_file_path', 'cluster_id', 'st
 
 RESOURCE_MAP = {
     "server_type_supported": ["hw", "vm"],
-    "storage_type_supported": ["rbod", "jbod", "ebod"],
-    "undesired_values": ["NA", "N/A", ""]
+    "storage_type_supported": ["rbod", "jbod", "ebod"]
 }
 
 

--- a/low-level/solution/lr2/server/health.py
+++ b/low-level/solution/lr2/server/health.py
@@ -164,13 +164,17 @@ class ServerHealth():
                         recommendation=None, specifics=None):
         """Sets health attributes for a component."""
         good_state = (status == "OK")
-        if description in const.RESOURCE_MAP["undesired_values"]:
+        if not description or \
+            description in const.RESOURCE_MAP["undesired_values"]:
             description = "%s %s in good health." % (
                 health_data.get("uid"),
                 'is' if good_state else 'is not')
-        if recommendation in const.RESOURCE_MAP["undesired_values"]:
-            recommendation = 'NOT AVAILABLE' if good_state\
-                else const.DEFAULT_RECOMMENDATION
+        if not good_state:
+            if not recommendation or \
+                recommendation in const.RESOURCE_MAP["undesired_values"]:
+                    recommendation = const.DEFAULT_RECOMMENDATION
+        else:
+            recommendation = None
         health_data["last_updated"] = int(time.time())
         health_data["health"].update({
             "status": status,

--- a/low-level/solution/lr2/server/health.py
+++ b/low-level/solution/lr2/server/health.py
@@ -164,11 +164,11 @@ class ServerHealth():
                         recommendation=None, specifics=None):
         """Sets health attributes for a component."""
         good_state = (status == "OK")
-        if description in ["NA", "N/A", None, ""]:
+        if description in const.RESOURCE_MAP["undesired_values"]:
             description = "%s %s in good health." % (
                 health_data.get("uid"),
                 'is' if good_state else 'is not')
-        if recommendation in ["NA", "N/A", None, ""]:
+        if recommendation in const.RESOURCE_MAP["undesired_values"]:
             recommendation = 'NA' if good_state\
                 else const.DEFAULT_RECOMMENDATION
         health_data["last_updated"] = int(time.time())

--- a/low-level/solution/lr2/server/health.py
+++ b/low-level/solution/lr2/server/health.py
@@ -169,7 +169,7 @@ class ServerHealth():
                 health_data.get("uid"),
                 'is' if good_state else 'is not')
         if recommendation in const.RESOURCE_MAP["undesired_values"]:
-            recommendation = 'NA' if good_state\
+            recommendation = 'NOT AVAILABLE' if good_state\
                 else const.DEFAULT_RECOMMENDATION
         health_data["last_updated"] = int(time.time())
         health_data["health"].update({

--- a/low-level/solution/lr2/server/health.py
+++ b/low-level/solution/lr2/server/health.py
@@ -164,11 +164,11 @@ class ServerHealth():
                         recommendation=None, specifics=None):
         """Sets health attributes for a component."""
         good_state = (status == "OK")
-        if not description:
+        if description in ["NA", "N/A", None, ""]:
             description = "%s %s in good health." % (
                 health_data.get("uid"),
                 'is' if good_state else 'is not')
-        if not recommendation:
+        if recommendation in ["NA", "N/A", None, ""]:
             recommendation = 'NA' if good_state\
                 else const.DEFAULT_RECOMMENDATION
         health_data["last_updated"] = int(time.time())

--- a/low-level/solution/lr2/server/health.py
+++ b/low-level/solution/lr2/server/health.py
@@ -165,16 +165,16 @@ class ServerHealth():
         """Sets health attributes for a component."""
         good_state = (status == "OK")
         if not description or \
-            description in const.RESOURCE_MAP["undesired_values"]:
+            description in const.HEALTH_UNDESIRED_VALS:
             description = "%s %s in good health." % (
                 health_data.get("uid"),
                 'is' if good_state else 'is not')
         if not good_state:
             if not recommendation or \
-                recommendation in const.RESOURCE_MAP["undesired_values"]:
+                recommendation in const.HEALTH_UNDESIRED_VALS:
                     recommendation = const.DEFAULT_RECOMMENDATION
         else:
-            recommendation = None
+            recommendation = "None"
         health_data["last_updated"] = int(time.time())
         health_data["health"].update({
             "status": status,

--- a/low-level/solution/lr2/storage/health.py
+++ b/low-level/solution/lr2/storage/health.py
@@ -135,13 +135,17 @@ class StorageHealth():
                         recommendation=None, specifics=None):
         """Sets health attributes for a component."""
         good_state = (status == "OK")
-        if description in const.RESOURCE_MAP["undesired_values"]:
+        if not description or \
+            description in const.RESOURCE_MAP["undesired_values"]:
             description = "%s %s in good health." % (
                 health_data.get("uid"),
                 'is' if good_state else 'is not')
-        if recommendation in const.RESOURCE_MAP["undesired_values"]:
-            recommendation = 'NOT AVAILABLE' if good_state\
-                else const.DEFAULT_RECOMMENDATION
+        if not good_state:
+            if not recommendation or \
+                recommendation in const.RESOURCE_MAP["undesired_values"]:
+                    recommendation = const.DEFAULT_RECOMMENDATION
+        else:
+            recommendation = None
         health_data["last_updated"] = int(time.time())
         health_data["health"].update({
             "status": status,

--- a/low-level/solution/lr2/storage/health.py
+++ b/low-level/solution/lr2/storage/health.py
@@ -136,16 +136,16 @@ class StorageHealth():
         """Sets health attributes for a component."""
         good_state = (status == "OK")
         if not description or \
-            description in const.RESOURCE_MAP["undesired_values"]:
+            description in const.HEALTH_UNDESIRED_VALS:
             description = "%s %s in good health." % (
                 health_data.get("uid"),
                 'is' if good_state else 'is not')
         if not good_state:
             if not recommendation or \
-                recommendation in const.RESOURCE_MAP["undesired_values"]:
+                recommendation in const.HEALTH_UNDESIRED_VALS:
                     recommendation = const.DEFAULT_RECOMMENDATION
         else:
-            recommendation = None
+            recommendation = "None"
         health_data["last_updated"] = int(time.time())
         health_data["health"].update({
             "status": status,

--- a/low-level/solution/lr2/storage/health.py
+++ b/low-level/solution/lr2/storage/health.py
@@ -135,11 +135,11 @@ class StorageHealth():
                         recommendation=None, specifics=None):
         """Sets health attributes for a component."""
         good_state = (status == "OK")
-        if not description:
+        if description in ["NA", "N/A", None, ""]:
             description = "%s %s in good health." % (
                 health_data.get("uid"),
                 'is' if good_state else 'is not')
-        if not recommendation:
+        if recommendation in ["NA", "N/A", None, ""]:
             recommendation = 'NA' if good_state\
                 else const.DEFAULT_RECOMMENDATION
         health_data["last_updated"] = int(time.time())

--- a/low-level/solution/lr2/storage/health.py
+++ b/low-level/solution/lr2/storage/health.py
@@ -140,7 +140,7 @@ class StorageHealth():
                 health_data.get("uid"),
                 'is' if good_state else 'is not')
         if recommendation in const.RESOURCE_MAP["undesired_values"]:
-            recommendation = 'NA' if good_state\
+            recommendation = 'NOT AVAILABLE' if good_state\
                 else const.DEFAULT_RECOMMENDATION
         health_data["last_updated"] = int(time.time())
         health_data["health"].update({

--- a/low-level/solution/lr2/storage/health.py
+++ b/low-level/solution/lr2/storage/health.py
@@ -135,11 +135,11 @@ class StorageHealth():
                         recommendation=None, specifics=None):
         """Sets health attributes for a component."""
         good_state = (status == "OK")
-        if description in ["NA", "N/A", None, ""]:
+        if description in const.RESOURCE_MAP["undesired_values"]:
             description = "%s %s in good health." % (
                 health_data.get("uid"),
                 'is' if good_state else 'is not')
-        if recommendation in ["NA", "N/A", None, ""]:
+        if recommendation in const.RESOURCE_MAP["undesired_values"]:
             recommendation = 'NA' if good_state\
                 else const.DEFAULT_RECOMMENDATION
         health_data["last_updated"] = int(time.time())


### PR DESCRIPTION
<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

EOS-23172: Description seen as 'N/A' for healthy Storage controller

## Solution Design:

<!-- For Bug and minor feature, describe the design changes here. 
For major feature, post the link to the solution page on the confluence Monitor team's space  -->

## Coding:

* [x] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [x] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [x] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [x] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [x] Manual testing done covering happy path and non-happy path?

## Integration:

* [x] If there is any interface change, did you communicate it to other components?
* [x] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [x] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
