### PR TITLE
EOS-20848:Stable 191: R2 : Sometimes fault resolved alert for kafka service is not reported.

### DIFF
--- a/low-level/framework/utils/iem.py
+++ b/low-level/framework/utils/iem.py
@@ -171,9 +171,5 @@ class Iem:
                 os.remove(IEM_INIT_FAILED)
             EventMessage.send(module=module, event_id=event_code,
                               severity=severity, message_blob=description)
-        except EventMessageError as e:
-            logger.error("Failed to send IEM alert."
-                         f"Error:{e}")
-        except Exception as err:
-            logger.error("Failed to send IEM alert."
-                         f"Error:{err}")
+        except (EventMessageError, Exception) as e:
+            logger.error(f"Failed to send IEM alert. Error:{e}")

--- a/low-level/framework/utils/iem.py
+++ b/low-level/framework/utils/iem.py
@@ -174,3 +174,6 @@ class Iem:
         except EventMessageError as e:
             logger.error("Failed to send IEM alert."
                          f"Error:{e}")
+        except Exception as err:
+            logger.error("Failed to send IEM alert."
+                         f"Error:{err}")

--- a/low-level/framework/utils/iem.py
+++ b/low-level/framework/utils/iem.py
@@ -13,12 +13,13 @@
 # about this software or licensing, please email opensource@seagate.com or
 # cortx-questions@seagate.com.
 
-
+import json
 import os
 import psutil
 
 from framework.base.sspl_constants import IEM_DATA_PATH, IEM_INIT_FAILED
 from framework.utils.service_logging import logger
+from framework.utils.store_queue import StoreQueue
 from cortx.utils.iem_framework import EventMessage
 from cortx.utils.iem_framework.error import EventMessageError
 
@@ -78,6 +79,8 @@ class Iem:
             "Cortx health alerts will get delivered to consumers like CSM.",
             ""]
     }
+
+    iem_store_queue = StoreQueue()
 
     def check_existing_iem_event(self, event_name, event_code):
         """Before logging iem, check if is already present."""
@@ -157,19 +160,31 @@ class Iem:
     @staticmethod
     def generate_iem(module, event_code, severity, description):
         """Generate iem and send it to a MessgaeBroker."""
+
+        IEM_msg = json.dumps(
+            {"iem": {"module": module, "event_code": event_code,
+                "severity": severity, "description": description}})
         try:
-            logger.info(f"Sending IEM alert for module:{module}"
-                        f" and event_code:{event_code}")
-            # check if IEM Framework initialized,
-            # if not, retry initializing the IEM Frameowork
-            if os.path.exists(IEM_INIT_FAILED):
-                with open(IEM_INIT_FAILED, 'r') as f:
-                    sspl_pid = f.read()
-                if sspl_pid and psutil.pid_exists(int(sspl_pid)):
-                    EventMessage.init(component='sspl', source='S')
-                    logger.info("IEM framework initialization completed!!")
-                os.remove(IEM_INIT_FAILED)
-            EventMessage.send(module=module, event_id=event_code,
-                              severity=severity, message_blob=description)
+            if Iem.iem_store_queue.is_empty():
+                logger.info(f"Sending IEM alert for module:{module}"
+                            f" and event_code:{event_code}")
+                # check if IEM Framework initialized,
+                # if not, retry initializing the IEM Frameowork
+                if os.path.exists(IEM_INIT_FAILED):
+                    with open(IEM_INIT_FAILED, 'r') as f:
+                        sspl_pid = f.read()
+                    if sspl_pid and psutil.pid_exists(int(sspl_pid)):
+                        EventMessage.init(component='sspl', source='S')
+                        logger.info("IEM framework initialization completed!!")
+                    os.remove(IEM_INIT_FAILED)
+                EventMessage.send(module=module, event_id=event_code,
+                                severity=severity, message_blob=description)
+            else:
+                logger.info(
+                    "'Accumulated iem queue' is not Empty."
+                        " Adding IEM to the end of the queue")
+                Iem.iem_store_queue.put(IEM_msg)
         except (EventMessageError, Exception) as e:
-            logger.error(f"Failed to send IEM alert. Error:{e}")
+            logger.error(f"Failed to send IEM alert. Error:{e}."
+                "Adding IEM in accumulated queue.")
+            Iem.iem_store_queue.put(IEM_msg)

--- a/low-level/sspl_ll_d
+++ b/low-level/sspl_ll_d
@@ -722,7 +722,7 @@ def initialize_iem():
     try:
         if os.path.exists(IEM_INIT_FAILED):
             os.remove(IEM_INIT_FAILED)
-        EventMessage.init(component=None, source='S')
+        EventMessage.init(component='sspl', source='S')
         logger.info("IEM framework initiated successfully!!!")
     except EventMessageError as e:
         # create IEM_INIT_FAILED file and log current sspl pid.


### PR DESCRIPTION
<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

<!--- Describe the problem this patch intends to solve. -->
Sometimes fault resolved alert when kafka service recovers from failure is not reported on message bus.

## Solution Design:

<!-- For Bug and minor feature, describe the design changes here. 
For major feature, post the link to the solution page on the confluence Monitor team's space  -->
Cause of issue:
- For kafka service failure we send the iem alert and for generating iem, in service_monitor class we are calling 'self.iem.iem_fault("KAFKA_NOT_ACTIVE")'  from iem.py file.
- but in case of kafka service unavailability 'EventMessage.send' (from iem.py file) fails with 'KafkaError'.  this is not getting handled in 'EventMessageError' exception. 'serviceMonitor' which is calling this method shutdown because of this unhandled exception and hence we are not receiving alerts for service state change.

Fix:
- Added exception handling in iem.py.

## Coding:

* [x] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [x] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [ ] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [ ] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [ ] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
