### PR TITLE
EOS-19806: Factory reset clear log data instead deleting log files.

### DIFF
--- a/low-level/files/opt/seagate/sspl/setup/sspl_reset.py
+++ b/low-level/files/opt/seagate/sspl/setup/sspl_reset.py
@@ -7,6 +7,7 @@ from framework.base.sspl_constants import (PRODUCT_FAMILY,
                                            sspl_config_path)
 from cortx.utils.service import DbusServiceHandler
 from cortx.utils.conf_store import Conf
+from cortx.utils.process import SimpleProcess
 from files.opt.seagate.sspl.setup.setup_logger import logger
 
 
@@ -22,11 +23,18 @@ class Reset:
             os.remove(filename)
 
     @classmethod
-    def del_files_from_dir(cls, fformat, dir_path):
+    def reset_log_files(cls, fformat, dir_path, del_file=False):
         for root, _, files in os.walk(dir_path):
             for file in files:
                 if file.endswith(fformat):
-                    os.remove(os.path.join(root, file))
+                    if del_file:
+                        os.remove(os.path.join(root, file))
+                        return
+                    cmd= f"truncate -s 0 > {os.path.join(root, file)}"
+                    _, error, returncode = SimpleProcess(cmd).run()
+                    if returncode != 0:
+                        logger.error("Failed to clear log file data"
+                                     f"ERROR:{error} CMD:{cmd}")
 
     def process(self):
         dbus_service = DbusServiceHandler()
@@ -41,11 +49,12 @@ class Reset:
         # Remove sspl data
         shutil.rmtree(DATA_PATH, ignore_errors=True)
 
-        # Remove log files
-        Reset.del_files_from_dir('.log', f"/var/log/{PRODUCT_FAMILY}/sspl/")
-        Reset.del_files_from_dir('.log.gz',
-                                 f"/var/log/{PRODUCT_FAMILY}/sspl/")
-        Reset.del_files_from_dir('.log', f"/var/log/{PRODUCT_FAMILY}/iem/")
-        Reset.del_files_from_dir('.log.gz',
-                                 f"/var/log/{PRODUCT_FAMILY}/iem/")
-
+        # Clear log data from log files and delete 'log.gz' files
+        Reset.reset_log_files('.log', f"/var/log/{PRODUCT_FAMILY}/sspl/")
+        Reset.reset_log_files('.log', f"/var/log/{PRODUCT_FAMILY}/iem/")
+        Reset.reset_log_files('.log.gz',
+                              f"/var/log/{PRODUCT_FAMILY}/sspl/",
+                              del_file=True)
+        Reset.reset_log_files('.log.gz',
+                              f"/var/log/{PRODUCT_FAMILY}/iem/",
+                              del_file=True)


### PR DESCRIPTION
<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

Factory reset interface deletes the log files for SSPL, so logs will not be generated untill rsyslog.service restarts

## Solution Design:

Clear log data instead of deleting the files

## Coding:

* [ ] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [ ] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [ ] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [ ] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [ ] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
