### PR TITLE
EOS-22875: Align Manifest/Health resource list with System resource m…

### DIFF
--- a/low-level/framework/utils/mon_utils.py
+++ b/low-level/framework/utils/mon_utils.py
@@ -20,6 +20,7 @@
 """
 
 import uuid
+from framework.utils.service_logging import logger
 
 
 class MonUtils():
@@ -49,3 +50,28 @@ class MonUtils():
             return replace_v
         else:
             return item
+
+    @staticmethod
+    def sort_by_specific_kv(data, key_path, log):
+        """
+        Accept list of dictionary and sort by key value.
+        data: list of dictionary
+               Examples:
+                    [{},{}]
+        key_path: Sort list on the basis of the key path.
+               Examples:
+                    '["health"]["specifics"][0]["serial-number"]'
+        log: log object.
+        """
+        sorted_data = []
+        try:
+            if key_path and data:
+                sorted_data = sorted(data, key=lambda k: eval(f'{k}{key_path}'))
+            else:
+                sorted_data = data
+        except Exception as err:
+            sorted_data = data
+            msg = 'Key: %s not found in data: %s for sorting: %s"' % (
+                key_path, data, err)
+            logger.error(log.svc_log(f"{msg}"))
+        return sorted_data

--- a/low-level/solution/lr2/server/health.py
+++ b/low-level/solution/lr2/server/health.py
@@ -82,6 +82,8 @@ class ServerHealth():
         self._ipmi = IpmiFactory().get_implementor("ipmitool")
         self.platform_sensor_list = ['Temperature', 'Voltage', 'Current']
         self.service = Service()
+        self.resource_indexing_map = ServerResourceMap.resource_indexing_map\
+            ["health"]
 
     def get_data(self, rpath):
         """Fetch health information for given rpath."""
@@ -295,6 +297,8 @@ class ServerHealth():
         if not add_overall_usage:
             cpu_data = per_cpu_data
 
+        sort_key_path = self.resource_indexing_map["hw"]["cpu"]
+        cpu_data = MonUtils.sort_by_specific_kv(cpu_data, sort_key_path, self.log)
         logger.debug(self.log.svc_log(
             f"CPU Health Data:{cpu_data}"))
         return cpu_data
@@ -566,6 +570,7 @@ class ServerHealth():
     def get_nw_ports_info(self):
         """Return the Network ports information."""
         network_cable_data = []
+        sort_key_path = None
         io_counters = psutil.net_io_counters(pernic=True)
 
         nw_instance = Network()
@@ -591,6 +596,7 @@ class ServerHealth():
                 self.get_nw_status(nw_instance, interface)
             specifics["nwStatus"] = nw_status
             specifics["nwCableConnStatus"] = nw_cable_conn_status
+            specifics["logical_name"] = interface
             # Map and set the interface health status and description.
             map_status = {"CONNECTED": "OK", "DISCONNECTED": "Disabled/Failed",
                           "UNKNOWN": "NA"}
@@ -601,6 +607,9 @@ class ServerHealth():
             self.set_health_data(nic_info, health_status, description=desc,
                                  specifics=[specifics])
             network_cable_data.append(nic_info)
+        sort_key_path = self.resource_indexing_map["hw"]["nw_port"]
+        network_cable_data = MonUtils.sort_by_specific_kv(
+            network_cable_data, sort_key_path, self.log)
         return network_cable_data
 
     def get_nw_status(self, nw_interface, interface):
@@ -627,12 +636,18 @@ class ServerHealth():
         """Get cortx service info in required format."""
         cortx_services = self.service.get_cortx_service_list()
         cortx_service_info = self.get_service_info(cortx_services)
+        sort_key_path = self.resource_indexing_map["sw"]["cortx_sw_services"]
+        cortx_service_info = MonUtils.sort_by_specific_kv(
+            cortx_service_info, sort_key_path, self.log)
         return cortx_service_info
 
     def get_external_service_info(self):
         """Get external service info in required format."""
         external_services = self.service.get_external_service_list()
         external_service_info = self.get_service_info(external_services)
+        sort_key_path = self.resource_indexing_map["sw"]["external_sw_services"]
+        external_service_info = MonUtils.sort_by_specific_kv(
+            external_service_info, sort_key_path, self.log)
         return external_service_info
 
     def get_service_info(self, services):
@@ -675,28 +690,42 @@ class ServerHealth():
     def get_disks_info(self):
         """Update and return server drive information in specific format."""
         disks = []
+        sort_key_path = None
         for disk in Disk.get_disks():
             uid = disk.path if disk.path else disk.id
             disk_health = self.get_health_template(uid, True)
             health_data = disk.get_health()
             health = "OK" if (health_data['SMART_health'] == "PASSED") else "Fault"
-            self.set_health_data(disk_health, health, specifics=[{"SMART": health_data}])
+            serial_number = disk.id.split("-")[-1] if disk.id else "NA"
+            health_data.update({"serial_number": serial_number})
+            self.set_health_data(disk_health, health, specifics=[{
+                "SMART": health_data}])
             disks.append(disk_health)
+        # Sort disk list by serial_number
+        sort_key_path = self.resource_indexing_map["hw"]["disk"]
+        disks = MonUtils.sort_by_specific_kv(disks, sort_key_path,
+            self.log)
         logger.debug(self.log.svc_log(
             f"Disk Health Data:{disks}"))
         return disks
 
     def get_psu_info(self):
         """Update and return PSU information in specific format."""
-        psus_health_data = []
+        psus_data = []
+        sort_key_path = None
         for psu in self.get_psus():
-            data = self.get_health_template(f'{psu["Location"]}', True)
-            health = "OK" if (psu["Status"] == "Present, OK") else "Fault"
+            psu = {k.lower().replace(" ", "_"): v for k,v in psu.items()}
+            data = self.get_health_template(f'{psu["location"]}', True)
+            health = "OK" if (psu["status"] == "Present, OK") else "Fault"
             self.set_health_data(data, health, specifics=psu)
-            psus_health_data.append(data)
+            psus_data.append(data)
+        # Sort disk list by serial_number
+        sort_key_path = self.resource_indexing_map["hw"]["psu"]
+        psus_data = MonUtils.sort_by_specific_kv(psus_data,
+            sort_key_path, self.log)
         logger.debug(self.log.svc_log(
-            f"PSU Health Data:{psus_health_data}"))
-        return psus_health_data
+            f"PSU Health Data:{psus_data}"))
+        return psus_data
 
     @staticmethod
     def get_psus():

--- a/low-level/solution/lr2/server/manifest.py
+++ b/low-level/solution/lr2/server/manifest.py
@@ -58,16 +58,17 @@ class ServerManifest():
             'part_number': 'part_number',
             'model_number': 'model_number',
             'physid': 'physical_id',
-            'version': 'version'
+            'version': 'version',
+            'logicalname': 'logical_name'
         }
         self.class_mapping = {
             'memory': 'hw>memory[%s]>%s',
             'disk': 'hw>disk[%s]>%s',
             'storage': 'hw>storage[%s]>%s',
             'system': 'hw>system[%s]>%s',
-            'processor': 'hw>processor[%s]>%s',
-            'network': 'hw>network[%s]>%s',
-            'power': 'hw>power[%s]>%s',
+            'processor': 'hw>cpu[%s]>%s',
+            'network': 'hw>nw_port[%s]>%s',
+            'power': 'hw>psu[%s]>%s',
             'volume': 'hw>volume[%s]>%s',
             'bus': 'hw>bus[%s]>%s',
             'bridge': 'hw>bridge[%s]>%s',
@@ -95,6 +96,8 @@ class ServerManifest():
         }
         self.service = Service()
         self.platform = Platform()
+        self.resource_indexing_map = ServerResourceMap.resource_indexing_map\
+            ["manifest"]
 
     def get_data(self, rpath):
         """Fetch manifest information for given rpath."""
@@ -204,6 +207,12 @@ class ServerManifest():
         # separately & uniquely
         if "disk" in lshw_data["hw"]:
             lshw_data["hw"]["disk"] = self.get_local_disk(lshw_data["hw"]["disk"])
+        # Sort list by serial_number
+        for resource, sort_key_path in self.resource_indexing_map["hw"].items():
+            if resource in lshw_data["hw"]:
+                sorted_data = MonUtils.sort_by_specific_kv(
+                    lshw_data["hw"][resource], sort_key_path, self.log)
+                lshw_data["hw"][resource] = sorted_data
         return lshw_data
 
     def get_hw_resources_info(self, server_hw_data, resource=False):
@@ -254,6 +263,8 @@ class ServerManifest():
             value = data.get(base_key+'>'+field)
         else:
             value = data.get(field)
+        if isinstance(value, list):
+            value = ','.join(value)
         value = value.replace(" (To be filled by O.E.M.)", "") \
             if value else 'NA'
         if field == 'id' and '>' in kv_key:
@@ -286,12 +297,18 @@ class ServerManifest():
         """Get cortx service info in required format."""
         cortx_services = self.service.get_cortx_service_list()
         cortx_service_info = self.get_service_info(cortx_services)
+        sort_key_path = self.resource_indexing_map["sw"]["cortx_sw_services"]
+        cortx_service_info = MonUtils.sort_by_specific_kv(
+            cortx_service_info, sort_key_path, self.log)
         return cortx_service_info
 
     def get_external_service_info(self):
         """Get external service info in required format."""
         external_services = self.service.get_external_service_list()
         external_service_info = self.get_service_info(external_services)
+        sort_key_path = self.resource_indexing_map["sw"]["external_sw_services"]
+        external_service_info = MonUtils.sort_by_specific_kv(
+            external_service_info, sort_key_path, self.log)
         return external_service_info
 
     def get_service_info(self, services):

--- a/low-level/solution/lr2/server/server_resource_map.py
+++ b/low-level/solution/lr2/server/server_resource_map.py
@@ -29,6 +29,33 @@ class ServerResourceMap(ResourceMap):
     """
 
     name = "server"
+    # Resources and their common key path.
+    resource_indexing_map = {
+        "health": {
+            "hw": {
+                "disk": "['health']['specifics'][0]['SMART']['serial_number']",
+                "psu": "['health']['specifics']['serial_number']",
+                "cpu": "['uid']",
+                "nw_port": "['health']['specifics'][0]['logical_name']"
+            },
+            "sw": {
+                "cortx_sw_services": "['uid']",
+                "external_sw_services": "['uid']"
+            }
+        },
+        "manifest":{
+            "hw": {
+                "disk": "['serial_number']",
+                "psu": "['serial_number']",
+                "cpu": "['uid']",
+                "nw_port": "['logical_name']"
+            },
+            "sw": {
+                "cortx_sw_services": "['uid']",
+                "external_sw_services": "['uid']"
+            }
+        }
+    }
 
     def __init__(self):
         """Initialize server."""

--- a/low-level/solution/lr2/storage/health.py
+++ b/low-level/solution/lr2/storage/health.py
@@ -58,6 +58,8 @@ class StorageHealth():
             "hw": hw_resources,
             "fw": fw_resources
         }
+        self.resource_indexing_map = StorageResourceMap.resource_indexing_map\
+            ["health"]
 
     def get_data(self, rpath):
         """
@@ -176,11 +178,16 @@ class StorageHealth():
                 health = fan_module.get('health')
                 fan_module_resp = self.get_health_template(uid, is_fru=True)
                 specifics = [self.get_fan_specfics(fan) for fan in fan_module['fan']]
+                fan_key_path = self.resource_indexing_map["hw"]["fan"]
+                specifics = MonUtils.sort_by_specific_kv(specifics,
+                    fan_key_path, self.log)
                 self.set_health_data(fan_module_resp, health, specifics=specifics)
                 response.append(fan_module_resp)
             logger.debug(self.log.svc_log(f"Fan modules health Data:{response}"))
         else:
             logger.error(self.log.svc_log("No response received from fan modules"))
+        sort_key_path = self.resource_indexing_map["hw"]["fan"]
+        response = MonUtils.sort_by_specific_kv(response, sort_key_path, self.log)
         return response
 
     def get_storage_health_info(self):
@@ -266,6 +273,8 @@ class StorageHealth():
             data.append(controller_dict)
             logger.debug(self.log.svc_log(
                 f"Contollers Health Data:{data}"))
+        sort_key_path = self.resource_indexing_map["hw"]["controller"]
+        data = MonUtils.sort_by_specific_kv(data, sort_key_path, self.log)
         return data
 
     def get_psu_info(self):
@@ -285,7 +294,8 @@ class StorageHealth():
                     "dc33v": psu.get("dc33v", "NA"),
                     "dc12i": psu.get("dc12i", "NA"),
                     "dc5i": psu.get("dc5i", "NA"),
-                    "dctemp": psu.get("dctemp", "NA")
+                    "dctemp": psu.get("dctemp", "NA"),
+                    "serial-number": psu.get("serial-number", "NA")
                 }
             ]
             psu_dict = self.get_health_template(uid, is_fru=True)
@@ -294,6 +304,8 @@ class StorageHealth():
             data.append(psu_dict)
             logger.debug(self.log.svc_log(
                 f"PSU Health Data:{data}"))
+        sort_key_path = self.resource_indexing_map["hw"]["psu"]
+        data = MonUtils.sort_by_specific_kv(data, sort_key_path, self.log)
         return data
 
     def get_platform_sensors_info(self):
@@ -445,6 +457,9 @@ class StorageHealth():
             uid = sideplane.get("durable-id", "NA")
             expanders = sideplane.get("expanders")
             expander_data = self.get_expander_data(expanders)
+            sort_key_path = self.resource_indexing_map["hw"]["sideplane_expander"]
+            expander_data = MonUtils.sort_by_specific_kv(expander_data,
+                sort_key_path, self.log)
             health = sideplane.get("health", "NA")
             recommendation = sideplane.get("health-recommendation", "NA")
             specifics = [
@@ -461,6 +476,9 @@ class StorageHealth():
                 specifics=specifics)
 
             sideplane_expander_data.append(sideplane_dict)
+        sort_key_path = self.resource_indexing_map["hw"]["sideplane_expander"]
+        sideplane_expander_data = MonUtils.sort_by_specific_kv(
+            sideplane_expander_data, sort_key_path, self.log)
         logger.debug(self.log.svc_log(
             f"Sideplane Expander Health Data:{sideplane_expander_data}"))
         return sideplane_expander_data
@@ -532,6 +550,9 @@ class StorageHealth():
             self.set_health_data(
                 drives_dict, status, description, recommendation, specifics)
             drive_data.append(drives_dict)
+        sort_key_path = self.resource_indexing_map["hw"]["disk"]
+        drive_data = MonUtils.sort_by_specific_kv(drive_data, sort_key_path,
+            self.log)
         logger.debug(self.log.svc_log(
             f"disk Health data:{drive_data}"))
         return drive_data

--- a/low-level/solution/lr2/storage/storage_resource_map.py
+++ b/low-level/solution/lr2/storage/storage_resource_map.py
@@ -28,6 +28,27 @@ class StorageResourceMap(ResourceMap):
     """
 
     name = "storage"
+    # Resources and their common key path.
+    resource_indexing_map = {
+        "health": {
+            "hw": {
+                "controller": "['uid']",
+                "psu": "['uid']",
+                "fan": "['uid']",
+                "disk": "['uid']",
+                "sideplane_expander": "['uid']"
+            }
+        },
+        "manifest":{
+            "hw": {
+                "controller": "['uid']",
+                "psu": "['uid']",
+                "fan": "['uid']",
+                "disk": "['uid']",
+                "sideplane_expander": "['uid']"
+            }
+        }
+    }
 
     def __init__(self):
         """Initialize storage."""


### PR DESCRIPTION
…ap (#487)

--> Discovery server data mapped with the below resources.
1) hw => disk, psu, nw_port
2) sw => cortx_sw_services, external_sw_services

--> Discovery storage data mapped with the below resources.
1) hw => disk, psu, controller, fan, sideplane_expander

Signed-off-by: Satish Darade <satish.darade@seagate.com>

Co-authored-by: Chetan S Deshmukh <chetan.deshmukh@seagate.com>

<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

<!--- Describe the problem this patch intends to solve. -->

## Solution Design:

<!-- For Bug and minor feature, describe the design changes here. 
For major feature, post the link to the solution page on the confluence Monitor team's space  -->

## Coding:

* [ ] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [ ] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [ ] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [ ] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [ ] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [ ] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [ ] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
