### PR TITLE
EOS-22875: Resolved sorting/mapping discrepancy for server nw_port resource.

### DIFF
--- a/low-level/solution/lr2/server/health.py
+++ b/low-level/solution/lr2/server/health.py
@@ -570,6 +570,7 @@ class ServerHealth():
     def get_nw_ports_info(self):
         """Return the Network ports information."""
         network_cable_data = []
+        loopback_interface = {}
         sort_key_path = None
         io_counters = psutil.net_io_counters(pernic=True)
 
@@ -606,10 +607,17 @@ class ServerHealth():
             )
             self.set_health_data(nic_info, health_status, description=desc,
                                  specifics=[specifics])
-            network_cable_data.append(nic_info)
+            # Separating out loopback interface and ethernet interface
+            # data to make correct sorting/mapping with manifest data.
+            if interface == 'lo':
+                loopback_interface = nic_info
+            else:
+                network_cable_data.append(nic_info)
         sort_key_path = self.resource_indexing_map["hw"]["nw_port"]
         network_cable_data = MonUtils.sort_by_specific_kv(
             network_cable_data, sort_key_path, self.log)
+        if loopback_interface:
+            network_cable_data.append(loopback_interface)
         return network_cable_data
 
     def get_nw_status(self, nw_interface, interface):

--- a/low-level/solution/lr2/server/manifest.py
+++ b/low-level/solution/lr2/server/manifest.py
@@ -208,11 +208,22 @@ class ServerManifest():
         if "disk" in lshw_data["hw"]:
             lshw_data["hw"]["disk"] = self.get_local_disk(lshw_data["hw"]["disk"])
         # Sort list by serial_number
+        eth_ctrl = []
         for resource, sort_key_path in self.resource_indexing_map["hw"].items():
             if resource in lshw_data["hw"]:
+                if resource == "nw_port":
+                    # Separating out ethernet controller and ethernet interface
+                    # data for sorting.
+                    eth_ctrl = [eth_ctr for eth_ctr in lshw_data["hw"][resource] \
+                        if eth_ctr['logical_name']=='NA']
+                    lshw_data["hw"][resource] = [eth_interface for eth_interface \
+                        in lshw_data["hw"][resource] if eth_interface[
+                            'logical_name']!='NA']
                 sorted_data = MonUtils.sort_by_specific_kv(
                     lshw_data["hw"][resource], sort_key_path, self.log)
                 lshw_data["hw"][resource] = sorted_data
+            if resource == "nw_port" and eth_ctrl:
+                lshw_data["hw"][resource] += eth_ctrl
         return lshw_data
 
     def get_hw_resources_info(self, server_hw_data, resource=False):


### PR DESCRIPTION
Signed-off-by: Satish Darade <satish.darade@seagate.com>

<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

<!--- Describe the problem this patch intends to solve. -->

## Solution Design:

<!-- For Bug and minor feature, describe the design changes here. 
For major feature, post the link to the solution page on the confluence Monitor team's space  -->

## Coding:

* [x] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [x] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [x] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [x] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [x] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
