### PR TITLE
EOS-23183: LDR R2 SSPL: Sw Services monitoring - introduce configurable wait time before raising alert

### DIFF
--- a/low-level/files/opt/seagate/sspl/conf/sspl.conf.LR2.yaml
+++ b/low-level/files/opt/seagate/sspl/conf/sspl.conf.LR2.yaml
@@ -143,7 +143,7 @@ SERVICEMONITOR:
    thread_sleep: 1
    polling_frequency: 15
    threshold_inactive_time: 180
-   threshold_active_time: 30
+   threshold_waiting_time: 30
    monitored_services:
       - hare-consul-agent.service
       - elasticsearch.service

--- a/low-level/sensors/impl/centos_7/service_monitor.py
+++ b/low-level/sensors/impl/centos_7/service_monitor.py
@@ -70,7 +70,7 @@ class ActiveState:
     @staticmethod
     def enter(service):
         for set_type in [
-            service.non_active,
+                service.non_active,
                 service.failed_waiting_services,
                 service.active_waiting_services]:
             set_type.discard(service.name)
@@ -85,7 +85,7 @@ class FailedState:
     @staticmethod
     def enter(service):
         for set_type in [
-            service.non_active,
+                service.non_active,
                 service.failed_waiting_services,
                 service.active_waiting_services]:
             set_type.discard(service.name)
@@ -170,7 +170,7 @@ class Service:
     # into the active_waiting_services list.
     active_waiting_services = set()
     # if service state changed to Failed state add service name
-    # in failed_service list.
+    # in failed_waiting_services list.
     failed_waiting_services = set()
     monitoring_disabled = set()
 

--- a/low-level/sensors/impl/centos_7/service_monitor.py
+++ b/low-level/sensors/impl/centos_7/service_monitor.py
@@ -69,8 +69,11 @@ class ActiveState:
 
     @staticmethod
     def enter(service):
-        service.state_enter_timestamp = time.time()
-        Service.non_active.discard(service.name)
+        for set_type in [
+            service.non_active,
+                service.failed_waiting_services,
+                service.active_waiting_services]:
+            set_type.discard(service.name)
 
 
 class FailedState:
@@ -81,8 +84,11 @@ class FailedState:
 
     @staticmethod
     def enter(service):
-        service.state_enter_timestamp = time.time()
-        Service.non_active.discard(service.name)
+        for set_type in [
+            service.non_active,
+                service.failed_waiting_services,
+                service.active_waiting_services]:
+            set_type.discard(service.name)
 
 
 class InactiveState:
@@ -95,6 +101,10 @@ class InactiveState:
     def enter(service):
         service.nonactive_enter_timestamp = time.time()
         Service.non_active.add(service.name)
+        for set_type in [
+                service.failed_waiting_services,
+                service.active_waiting_services]:
+            set_type.discard(service.name)
 
 
 class DisabledState:
@@ -157,11 +167,11 @@ class Service:
     alerts = Queue()
     non_active = set()
     # once fault resolved detected for service, add service name
-    # into the active_services list.
-    active_services = set()
+    # into the active_waiting_services list.
+    active_waiting_services = set()
     # if service state changed to Failed state add service name
     # in failed_service list.
-    failed_services = set()
+    failed_waiting_services = set()
     monitoring_disabled = set()
 
     def __init__(self, unit):
@@ -179,7 +189,7 @@ class Service:
         self.previous_substate = "N/A"
         self.previous_pid = "N/A"
         self.nonactive_enter_timestamp = time.time()
-        self.state_enter_timestamp = time.time()
+        self.waiting_timestamp = time.time()
         self.nonactive_threshold = int(
             Conf.get(SSPL_CONF,
                      f"{ServiceMonitor.name().upper()}>threshold_inactive_time",
@@ -202,7 +212,7 @@ class Service:
         return time.time() - self.nonactive_enter_timestamp > self.nonactive_threshold
 
     def in_same_state_for_threshold_time(self):
-        return time.time() - self.state_enter_timestamp > self.threshold_waiting_time
+        return time.time() - self.waiting_timestamp > self.threshold_waiting_time
 
     def new_service_state(self, new_state):
         if self._service_state != new_state:
@@ -236,26 +246,24 @@ class Service:
         if self.state != self.previous_state:
             if self.state == "active":
                 if self._service_state is FailedState:
+                    self.waiting_timestamp = time.time()
+                    Service.active_waiting_services.add(self.name)
+                elif self._service_state is InactiveState:
                     self.new_service_state(ActiveState)
-                    Service.active_services.add(self.name)
-                if self._service_state is InactiveState:
-                    self.new_service_state(ActiveState)
-                if self.name in Service.failed_services:
-                    Service.failed_services.discard(self.name)
+                # TODO: Handle discarding service from state list
+                # in new_service_state function.
+                Service.failed_waiting_services.discard(self.name)
             elif self.state == "failed":
                 if self._service_state is not FailedState:
-                    self.new_service_state(FailedState)
-                    Service.failed_services.add(self.name)
-                if self.name in Service.active_services:
-                    Service.active_services.discard(self.name)
+                    self.waiting_timestamp = time.time()
+                    Service.failed_waiting_services.add(self.name)
+                Service.active_waiting_services.discard(self.name)
             else:
                 # Avoid raising duplicate alerts
                 if self._service_state != FailedState:
                     self.new_service_state(InactiveState)
-                if self.name in Service.active_services:
-                    Service.active_services.discard(self.name)
-                elif self.name in Service.failed_services:
-                    Service.failed_services.discard(self.name)
+                Service.active_waiting_services.discard(self.name)
+                Service.failed_waiting_services.discard(self.name)
                 self.dump_to_cache()
 
     def handle_unit_state_change(self):
@@ -275,7 +283,7 @@ class Service:
         service.new_service_state(data["service_monitor_state"])
         service.state = data["service_state"]
         service.nonactive_enter_timestamp = data["nonactive_enter_timestamp"]
-        service.state_enter_timestamp = data["state_enter_timestamp"]
+        service.waiting_timestamp = data["waiting_timestamp"]
         return service
 
     def dump_to_cache(self):
@@ -286,7 +294,7 @@ class Service:
             "service_state": self.state,
             "service_monitor_state": self._service_state,
             "nonactive_enter_timestamp": self.nonactive_enter_timestamp,
-            "state_enter_timestamp": self.state_enter_timestamp
+            "waiting_timestamp": self.waiting_timestamp
         }
         store.put(data, f"{CACHE_PATH}/{self.name}")
 
@@ -387,9 +395,8 @@ class ServiceMonitor(SensorThread, InternalMsgQ):
                         self.initialize_service(service)
                     for service in Service.monitoring_disabled.copy():
                         self.services[service].new_unit_state(EnabledState)
-                    # Check for services in intermediate state(not active)
-                    self.check_nonactive_services()
-                    self.service_waiting_time()
+                    # Check services in same state for threshold time
+                    self.check_service_threshold_time()
                 time.sleep(self.thread_sleep)
                 iterations += 1
             logger.info("ServiceMonitor gracefully breaking out " +
@@ -463,37 +470,30 @@ class ServiceMonitor(SensorThread, InternalMsgQ):
         self._loop = GLib.MainLoop()
         self.context = self._loop.get_context()
 
-    def check_nonactive_services(self):
+    def check_service_threshold_time(self):
         """
-           Monitor non-active Services.
+            Monitor active, non-active(intermediate state) and failed services.
 
-           Raise FAULT Alert if any of the not-active services has exceeded
-           the threshold time for inactivity.
+            Raise alert for services
+            if service stays in same state for threshhold time.
         """
+        for service in Service.active_waiting_services.copy():
+            if self.services[service].in_same_state_for_threshold_time():
+                self.services[service].new_service_state(ActiveState)
+                self.raise_alert(
+                    self.get_alert(self.services[service], ResolvedAlert))
+
+        for service in Service.failed_waiting_services.copy():
+            if self.services[service].in_same_state_for_threshold_time():
+                self.services[service].new_service_state(FailedState)
+                self.raise_alert(
+                    self.get_alert(self.services[service], FailedAlert))
+
         for service in Service.non_active.copy():
             if self.services[service].is_nonactive_for_threshold_time():
                 self.services[service].new_service_state(FailedState)
                 self.raise_alert(self.get_alert(self.services[service],
                                                 InactiveAlert))
-
-    def service_waiting_time(self):
-        """
-            Monitor active and failed services.
-
-            Raise alert for services
-            if service stays in same state for threshhold time.
-        """
-        for service in Service.active_services.copy():
-            if self.services[service].in_same_state_for_threshold_time():
-                self.raise_alert(
-                    self.get_alert(self.services[service], ResolvedAlert))
-                Service.active_services.discard(service)
-
-        for service in Service.failed_services.copy():
-            if self.services[service].in_same_state_for_threshold_time():
-                self.raise_alert(
-                    self.get_alert(self.services[service], FailedAlert))
-                Service.failed_services.discard(service)
 
     def raise_iem(self, service, alert_type):
         """Raise iem alert for kafka service."""

--- a/sspl_test/alerts/os/test_service_monitor_sensor.py
+++ b/sspl_test/alerts/os/test_service_monitor_sensor.py
@@ -97,7 +97,7 @@ def test_service_failed_alert(args):
     check_sspl_ll_is_running()
     check_service_is_running(service_name)
     simulate_service_alerts.simulate_fault_alert()
-    time.sleep(5)
+    time.sleep(WAIT_TIME)
     sensor_response = read_ingress_queue()
     assert_on_mismatch(sensor_response, "fault")
     simulate_service_alerts.restore_service_file()

--- a/unittests/test_service_monitor.py
+++ b/unittests/test_service_monitor.py
@@ -40,7 +40,8 @@ class TestServiceMonitor(unittest.TestCase):
         self.mocked_conf_values = {
             "SERVICEMONITOR>thread_sleep": "1",
             "SERVICEMONITOR>polling_frequency": "5",
-            "SERVICEMONITOR>threshold_inactive_time": "10"
+            "SERVICEMONITOR>threshold_inactive_time": "10",
+            "SERVICEMONITOR>threshold_waiting_time": "10"
         }
         self.mocked_properties_value = {
             "Id": "spam.service",
@@ -207,7 +208,7 @@ class TestServiceMonitor(unittest.TestCase):
             "service_state": "inactive",
             "service_monitor_state": InactiveState,
             "nonactive_enter_timestamp": time.time() - 999,
-            "state_enter_timestamp": time.time()
+            "waiting_timestamp": time.time()
         })
         self.service_monitor.initialize(Mock(), Mock(), Mock())
         self.assertIs(

--- a/unittests/test_service_monitor.py
+++ b/unittests/test_service_monitor.py
@@ -115,6 +115,9 @@ class TestServiceMonitor(unittest.TestCase):
             fault_alert["sensor_request_type"]["service_status_alert"][
                 "specific_info"]["state"], "failed")
 
+    @patch(
+        'sensors.impl.centos_7.service_monitor.Service.in_same_state_for_threshold_time',
+        new=Mock(return_value=True))
     def test_fault_alert_if_service_change_state_from_active_to_failed(self):
         self.service_active_at_start()
         self.mocked_properties_value["ActiveState"] = "failed"
@@ -151,7 +154,7 @@ class TestServiceMonitor(unittest.TestCase):
                                     "spam.service"].properties_changed_handler,
                                 "", "", ""))
         self.service_monitor.services[
-            "spam.service"].is_active_for_threshold_time = Mock(
+            "spam.service"].in_same_state_for_threshold_time = Mock(
             return_value=True)
         self.service_monitor_run_iteration()
         self.assertEqual(self.service_monitor._write_internal_msgQ.call_count,
@@ -168,6 +171,9 @@ class TestServiceMonitor(unittest.TestCase):
             resolved_alert["sensor_request_type"]["service_status_alert"][
                 "specific_info"]["state"], "active")
 
+    @patch(
+        'sensors.impl.centos_7.service_monitor.Service.in_same_state_for_threshold_time',
+        new=Mock(return_value=True))
     def fail_service_at_start(self):
         self.mocked_properties_value["ActiveState"] = "failed"
         self.service_monitor.initialize(Mock(), Mock(), Mock())
@@ -201,7 +207,7 @@ class TestServiceMonitor(unittest.TestCase):
             "service_state": "inactive",
             "service_monitor_state": InactiveState,
             "nonactive_enter_timestamp": time.time() - 999,
-            "active_enter_timestamp": time.time()
+            "state_enter_timestamp": time.time()
         })
         self.service_monitor.initialize(Mock(), Mock(), Mock())
         self.assertIs(
@@ -220,6 +226,10 @@ class TestServiceMonitor(unittest.TestCase):
         self.service_monitor_run_iteration()
         self.service_monitor._write_internal_msgQ.assert_not_called()
 
+
+    @patch(
+        'sensors.impl.centos_7.service_monitor.Service.in_same_state_for_threshold_time',
+        new=Mock(return_value=True))
     def test_alert_for_enabled_service(self):
         # Service is disabled at start
         self.test_no_alert_for_disabled_service()


### PR DESCRIPTION

Signed-off-by: Shriya Deshmukh <shriya.deshmukh@seagate.com>

<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

<!--- Describe the problem this patch intends to solve. -->
For External services for major state transitions, alerts are raised immediately, HA will take action based on alerts.
But there is a possibility that systemd may be trying to recover the service as per the service file configs already, which would make service active quickly and HA may not need to take any action. 

## Solution Design:

<!-- For Bug and minor feature, describe the design changes here. 
For major feature, post the link to the solution page on the confluence Monitor team's space  -->
Introduce threshold_wait time before raising alert for external service major state transition.

## Coding:

* [ ] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [ ] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [ ] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [ ] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [ ] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [ ] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [ ] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
