### PR TITLE
EOS-23581: Prevent `/etc/sudoers.d/sspl` file deletion

### DIFF
--- a/low-level/framework/sspl_reinit
+++ b/low-level/framework/sspl_reinit
@@ -60,8 +60,13 @@ chmod 440 /etc/sudoers.d/sspl
 # removed by puppet-agent (Ref: LRL-495)
 PUPPET_CONF="/etc/puppetlabs/puppet/puppet.conf"
 [ -f $PUPPET_CONF ] && {
-    PUPPET_NOOP="noop = true"
-    grep -q "$PUPPET_NOOP" $PUPPET_CONF || echo "$PUPPET_NOOP" >> $PUPPET_CONF
+    grep -q "noop" $PUPPET_CONF
+    if [ $? -eq 0 ]
+    then
+        sed -i -E 's/noop\ *=\ *false/noop = true/g' $PUPPET_CONF
+    else
+        echo "noop = true" >> $PUPPET_CONF
+    fi
 }
 
 # Automatically install dependencies based on config file

--- a/low-level/framework/sspl_reinit
+++ b/low-level/framework/sspl_reinit
@@ -60,7 +60,7 @@ chmod 440 /etc/sudoers.d/sspl
 # removed by puppet-agent (Ref: LRL-495)
 PUPPET_CONF="/etc/puppetlabs/puppet/puppet.conf"
 [ -f $PUPPET_CONF ] && {
-    grep -q "noop" $PUPPET_CONF
+    grep -q "noop\s*=.*" $PUPPET_CONF
     if [ $? -eq 0 ]
     then
         sed -i -E 's/noop\ *=\ *false/noop = true/g' $PUPPET_CONF

--- a/low-level/framework/sspl_reinit
+++ b/low-level/framework/sspl_reinit
@@ -59,15 +59,7 @@ chmod 440 /etc/sudoers.d/sspl
 # Set noop = true in puppet conf file to avoid the sspl auth file getting
 # removed by puppet-agent (Ref: LRL-495)
 PUPPET_CONF="/etc/puppetlabs/puppet/puppet.conf"
-[ -f $PUPPET_CONF ] && {
-    grep -q "noop\s*=.*" $PUPPET_CONF
-    if [ $? -eq 0 ]
-    then
-        sed -i -E 's/noop\ *=\ *false/noop = true/g' $PUPPET_CONF
-    else
-        echo "noop = true" >> $PUPPET_CONF
-    fi
-}
+[ -f $PUPPET_CONF ] && conf "ini://$PUPPET_CONF" set "agent>noop=true"
 
 # Automatically install dependencies based on config file
 # There is no --checkdeps and --autoinstall implemented in sspl-ll-cli.


### PR DESCRIPTION
Signed-off-by: Sumedh A. Kulkarni <sumedh.a.kulkarni@seagate.com>

<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:
Puppet-agent is deleting the /etc/sudoers.d/sspl file since the cmd to write noop = true has some issues. correction regarding the same is needed.
<!--- Describe the problem this patch intends to solve. -->

## Solution Design:

<!-- For Bug and minor feature, describe the design changes here. 
For major feature, post the link to the solution page on the confluence Monitor team's space  -->

## Coding:

* [x] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [x] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [x] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [x] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [x] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
