### PR TITLE
EOS-23333: DiskMonitor Persistent Cache Issue

### DIFF
--- a/low-level/sensors/impl/centos_7/disk_monitor.py
+++ b/low-level/sensors/impl/centos_7/disk_monitor.py
@@ -266,7 +266,7 @@ class DiskMonitor(SensorThread, InternalMsgQ):
                         "resource_id": resource_id,
                         "resource_type": resource_type,
                         "specific_info": specific_info,
-                        "is_faulty": False
+                        "faulty": False
                     }
 
                 for drive_path in removed_drives:
@@ -731,7 +731,7 @@ class DiskMonitor(SensorThread, InternalMsgQ):
                         "resource_id": resource_id,
                         "resource_type": resource_type,
                         "specific_info": specific_info,
-                        "is_faulty": False
+                        "faulty": False
                     }
                     self._update_drive_faults()
                     store.put(self._existing_drive, self.disk_cache_path)
@@ -1104,14 +1104,14 @@ class DiskMonitor(SensorThread, InternalMsgQ):
             # If smratctl command is not failing there will be no ["smartctl"]["message"][0]["string"] in response
             except (KeyError, IndexError):
                 try:
-                    is_drive_faulty = not response['smart_status']['passed']
+                    fault_detected = not response['smart_status']['passed']
                 # If ['smart_status']['passed'] not present in response, consider it as fault
                 except KeyError:
-                    is_drive_faulty = True
+                    fault_detected = True
 
-            if not self._existing_drive[object_path]['is_faulty'] and \
-                is_drive_faulty:
-                self._existing_drive[object_path]['is_faulty'] = True
+            if not self._existing_drive[object_path]['faulty'] and \
+                fault_detected:
+                self._existing_drive[object_path]['faulty'] = True
                 self._drives[object_path][self.DRIVE_FAULT_ATTR] = self._get_drive_fault_info(object_path)
                 resource_type = self._get_resource_type(object_path)
                 specific_info = self._get_specific_info(object_path, self.DISK_FAULT_ALERT_TYPE)
@@ -1121,9 +1121,9 @@ class DiskMonitor(SensorThread, InternalMsgQ):
                                resource_type,
                                resource_id,
                                specific_info)
-            elif self._existing_drive[object_path]['is_faulty'] and \
-                not is_drive_faulty:
-                self._existing_drive[object_path]['is_faulty'] = False
+            elif self._existing_drive[object_path]['faulty'] and \
+                not fault_detected:
+                self._existing_drive[object_path]['faulty'] = False
                 self._drives[object_path][self.DRIVE_FAULT_ATTR] = self._get_drive_fault_info(object_path)
                 resource_type = self._get_resource_type(object_path)
                 specific_info = self._get_specific_info(object_path, self.DISK_FAULT_RESOLVED_ALERT_TYPE)

--- a/low-level/sensors/impl/centos_7/disk_monitor.py
+++ b/low-level/sensors/impl/centos_7/disk_monitor.py
@@ -246,15 +246,37 @@ class DiskMonitor(SensorThread, InternalMsgQ):
             with self._drive_info_lock:
                 # Prepare drives to monitor
                 self._drives = self._get_drives()
-                # send msg for new drives
-                for drive_path in self._drives.keys():
-                    if drive_path not in self._existing_drive:
-                        drive = self._drives[drive_path][self.DRIVE_DBUS_INFO]
-                        resource_type = self._get_resource_type(drive_path)
-                        specific_info = self._get_specific_info(drive_path, self.DISK_INSERTED_ALERT_TYPE)
-                        resource_id = self._drive_by_path.get(drive_path, str(drive["Id"]))
-                        self._send_msg(self.DISK_INSERTED_ALERT_TYPE, resource_type, resource_id, specific_info)
-                        self._existing_drive.update({drive_path: False})
+                # Send msg for drives which were added or removed
+                # when sspl was inactive.
+                detected_drives = set(self._drives.keys())
+                existing_drives = set(self._existing_drive.keys())
+                removed_drives = existing_drives - detected_drives
+                added_drives = detected_drives - existing_drives
+
+                for drive_path in added_drives:
+                    drive = self._drives[drive_path][self.DRIVE_DBUS_INFO]
+                    resource_type = self._get_resource_type(drive_path)
+                    specific_info = self._get_specific_info(
+                        drive_path, self.DISK_INSERTED_ALERT_TYPE)
+                    resource_id = self._drive_by_path.get(drive_path,
+                                                          str(drive["Id"]))
+                    self._send_msg(self.DISK_INSERTED_ALERT_TYPE,
+                                   resource_type, resource_id, specific_info)
+                    self._existing_drive[drive_path] = {
+                        "resource_id": resource_id,
+                        "resource_type": resource_type,
+                        "specific_info": specific_info,
+                        "is_faulty": False
+                    }
+
+                for drive_path in removed_drives:
+                    drive = self._existing_drive[drive_path]
+                    self._send_msg(self.DISK_REMOVED_ALERT_TYPE,
+                                   drive['resource_type'],
+                                   drive['resource_id'],
+                                   drive['specific_info'])
+                    del self._existing_drive[drive_path]
+
                 self._update_drive_faults()
                 store.put(self._existing_drive, self.disk_cache_path)
 
@@ -705,7 +727,12 @@ class DiskMonitor(SensorThread, InternalMsgQ):
                     self._send_msg(self.DISK_INSERTED_ALERT_TYPE, resource_type, resource_id, specific_info)
 
                     # Update cache with latest info
-                    self._existing_drive.update({object_path: False})
+                    self._existing_drive[object_path] = {
+                        "resource_id": resource_id,
+                        "resource_type": resource_type,
+                        "specific_info": specific_info,
+                        "is_faulty": False
+                    }
                     self._update_drive_faults()
                     store.put(self._existing_drive, self.disk_cache_path)
 
@@ -1082,8 +1109,9 @@ class DiskMonitor(SensorThread, InternalMsgQ):
                 except KeyError:
                     is_drive_faulty = True
 
-            if not self._existing_drive[object_path] and is_drive_faulty:
-                self._existing_drive[object_path] = True
+            if not self._existing_drive[object_path]['is_faulty'] and \
+                is_drive_faulty:
+                self._existing_drive[object_path]['is_faulty'] = True
                 self._drives[object_path][self.DRIVE_FAULT_ATTR] = self._get_drive_fault_info(object_path)
                 resource_type = self._get_resource_type(object_path)
                 specific_info = self._get_specific_info(object_path, self.DISK_FAULT_ALERT_TYPE)
@@ -1093,8 +1121,9 @@ class DiskMonitor(SensorThread, InternalMsgQ):
                                resource_type,
                                resource_id,
                                specific_info)
-            elif self._existing_drive[object_path] and not is_drive_faulty:
-                self._existing_drive[object_path] = False
+            elif self._existing_drive[object_path]['is_faulty'] and \
+                not is_drive_faulty:
+                self._existing_drive[object_path]['is_faulty'] = False
                 self._drives[object_path][self.DRIVE_FAULT_ATTR] = self._get_drive_fault_info(object_path)
                 resource_type = self._get_resource_type(object_path)
                 specific_info = self._get_specific_info(object_path, self.DISK_FAULT_RESOLVED_ALERT_TYPE)


### PR DESCRIPTION

Signed-off-by: Sumedh A. Kulkarni <sumedh.a.kulkarni@seagate.com>

<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:
 There are 2 cases of persistent cache one of them is handled the second case is not handled, 
As per my observation,
1. If a drive is not present in the persistent cache and we insert the disk when sspl is off, we get disk insertion alert when sspl starts.
2. If a drive is present in the persistent cache and we remove the disk when sspl is off, we don't get the disk removal alert when sspl starts.
<!--- Describe the problem this patch intends to solve. -->

## Solution Design:
Handle the second case explained in Problem Statement.
Add information about drives in cache, so that when drive is removed during sspl inactivity, we will stil have the information about drive removed even when it's inaccesible.
<!-- For Bug and minor feature, describe the design changes here. 
For major feature, post the link to the solution page on the confluence Monitor team's space  -->

## Coding:

* [x] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [x] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [x] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [x] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [x] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
