### PR TITLE
EOS-23612:no alerts seen after disabled/enabled a kafka service

### DIFF
--- a/low-level/sspl_ll_d
+++ b/low-level/sspl_ll_d
@@ -725,7 +725,7 @@ def initialize_iem():
             os.remove(IEM_INIT_FAILED)
         EventMessage.init(component='sspl', source='S')
         logger.info("IEM framework initiated successfully!!!")
-    except EventMessageError as e:
+    except (EventMessageError, Exception) as e:
         # create IEM_INIT_FAILED file and log current sspl pid.
         Utility().create_file(IEM_INIT_FAILED)
         with open(IEM_INIT_FAILED, 'w') as f:


### PR DESCRIPTION
<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

<!--- Describe the problem this patch intends to solve. -->
No alerts seen for  kafka service failure and also observed iem errors in sspl.logs.

## Solution Design:

<!-- For Bug and minor feature, describe the design changes here. 
For major feature, post the link to the solution page on the confluence Monitor team's space  -->
- If kafka service failed EventMessage class initialization failed with kafkaerror.
- This exception is not handled in EventMessageError - added Exception handling for this in sspl_ll_d.
- before sending accumulated iem_msg, need to check if  EventMessage is initialized or not, if not initialize it first and then send iem.

## Coding:

* [x] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [x] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [ ] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [ ] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [ ] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
