### PR TITLE
EOS-23381 SSPL: Fix scripts that require access to Seagate's internal repo

### DIFF
--- a/cortx-monitorQuickstartGuide.md
+++ b/cortx-monitorQuickstartGuide.md
@@ -94,7 +94,7 @@ This guide provides a step-by-step walkthrough for getting you CORTX-Monitor Ser
     :page_with_curl: **Notes:** 
     
     - If you get below error it may be because that your git version may be more thatn 2.x. Cortx requires 1.8.3.1. In that case
-      if go to `/root/cortx/cortx-monitor/` and run `git checkout main` 
+      if go to `~/cortx/cortx-monitor/` and run `git checkout main`
         ```
         error: pathspec 'main' did not match any file(s) known to git.
         make: *** [checkout] Error 1
@@ -144,7 +144,7 @@ This guide provides a step-by-step walkthrough for getting you CORTX-Monitor Ser
     TMPL_RACK_ID=RC01
     TMPL_SITE_ID=DC01
     TMPL_MACHINE_ID=0449364d92b2ba3915fcd8416014cff7
-    TMPL_HOSTNAME=ssc-vm-4778.colo.seagate.com
+    TMPL_HOSTNAME=<your vm hostname>
     TMPL_NODE_NAME=srvnode-1
     TMPL_SERVER_NODE_TYPE=VM
     TMPL_MGMT_INTERFACE=eth0

--- a/cortx-monitorQuickstartGuide.md
+++ b/cortx-monitorQuickstartGuide.md
@@ -24,38 +24,8 @@ This guide provides a step-by-step walkthrough for getting you CORTX-Monitor Ser
    
    :page_with_curl:**Note:** We recommended that you install Git Version 2.x.x.
 
-5. Setup yum repos.
-    
-     1. Run the command:
-            
-            `$ curl https://raw.githubusercontent.com/Seagate/cortx-prvsnr/dev/cli/src/cortx-prereqs.sh?token=APA75GY34Y2F5DJSOKDCZAK7ITSZC -o cortx-prereqs.sh; chmod a+x cortx-prereqs.sh`
-        
-            1. For Cent-OS VMs, run the command:
-        
-                `$ sh cortx-prereqs.sh` 
-        
-            2. For Rhel VMs, run the command: 
-        
-                `$ sh cortx-prereqs.sh --disable-sub-mgr`
-
-      2. Run the following commands if you are using a Seagate Internal VM:
-
-            ```shell
-            
-            $ BUILD_URL="http://cortx-storage.colo.seagate.com/releases/cortx/github/dev/rhel-7.7.1908/provisioner_last_successful"`
-            $ yum-config-manager --add-repo  $BUILD_URL
-            $ rpm --import  $BUILD_URL/RPM-GPG-KEY-Seagate
-            ```
-
-        :page_with_curl: **Notes:** 
-        
-      - If the https://raw.githubusercontent.com/Seagate/cortx-prvsnr/dev/cli/src/cortx-prereqs.sh?token=APA75GY34Y2F5DJSOKDCZAK7ITSZC link is not accessible, generate new one.
-      - Visit https://github.com/Seagate/cortx-prvsnr/blob/dev/cli/src/cortx-prereqs.sh and naviagte to RAW > Copy URL > Use the URL for deployment.
-      
-    3. Follow these instructions to [install dependencies](https://github.com/Seagate/cortx/blob/main/doc/InstallingDependencies.md) if you are using an external VM.
-
-    </p>
-    </details>
+</p>
+</details>
 
 
 ## 1.2 Clone the cortx-monitor repository
@@ -63,8 +33,7 @@ This guide provides a step-by-step walkthrough for getting you CORTX-Monitor Ser
 1. Run the following commands to clone the cortx-monitor repository to your local VM:
 
     ```shell
-    $ git clone --recursive https://github.com/Seagate/cortx-monitor.git -b main
-    $ cd cortx-monitor
+    $ cd /root && git clone https://github.com/Seagate/cortx --recursive --depth=1
     ```
 
 ## 1.3 Build the cortx-monitor source code
@@ -75,7 +44,7 @@ This guide provides a step-by-step walkthrough for getting you CORTX-Monitor Ser
 
 - cortx-monitor service named as sspl-ll.
 
-1. Before you build the RPM, you'll need to install the dependecies using:
+1. Before you build the RPM, you'll need to install the dependencies using:
 
     ```shell
     
@@ -103,57 +72,119 @@ This guide provides a step-by-step walkthrough for getting you CORTX-Monitor Ser
 
 2. Build RPMs
     
-   1. Switch to the directory where you've cloned cortx-monitor and run the command:
+   1. Checkout the main branch
    
-        `$ jenkins/build.sh`  
+        `docker run --rm -v /root/cortx:/cortx-workspace ghcr.io/seagate/cortx-build:centos-7.8.2003 make checkout BRANCH=main`  
     
     :page_with_curl: **Notes:** 
     
-    - It takes 2-3 minutes to generate RPMs.
-    - Once the RPMs are successfully generated, you can view it from:
+    - If you get below error it may be because that your git version may be more thatn 2.x. Cortx requires 1.8.3.1. In that case
+      if go to `/root/cortx/cortx-monitor/` and run `git checkout main` 
+        ```
+        error: pathspec 'main' did not match any file(s) known to git.
+        make: *** [checkout] Error 1
+        ```
+
+   2. Build cortx-monitor RPMs
+        ```
+        docker run --rm -v /var/artifacts:/var/artifacts -v /root/cortx:/cortx-workspace ghcr.io/seagate/cortx-build:centos-7.8.2003 make clean cortx-prvsnr cortx-monitor cortx-prereq release_build
+        ```
+        
+        If you check the location `/var/artifacts/0/`, you will see that Cortx RPMs and 3rd party packages are generated.
+
+        ```shell
+        ll /var/artifacts/0/
+        The system output displays as follows:
+
+        [root@ssc-vm-2699 ~]# ll /var/artifacts/0/
+        total 1608308
+        drwxr-xr-x  13 root root       4096 Aug 19 05:16 3rd_party
+        drwxr-xr-x   3 root root       4096 Aug 19 05:16 cortx_iso
+        -rw-r--r--   1 root root      19416 Aug 19 05:16 install-2.0.0-0.sh
+        drwxr-xr-x 198 root root       4096 Aug 19 05:16 python_deps
+        -rw-r--r--   1 root root  241635505 Jun 15 08:45 python-deps-1.0.0-0.tar.gz
+        -rw-r--r--   1 root root 1405229297 Jul  1 22:45 third-party-1.0.0-0.tar.gz
+        ```
     
-        `/root/rpmbuild/RPMS/noarch/` and,
-     
-        `/root/rpmbuild/RPMS/x86_64/`
-
-    **Sample Output:**
-    
-    ```shell
-
-    [local_host cortx-monitor]# ls -lrt /root/rpmbuild/RPMS/noarch/
-    total 59056
-    -rw-r--r-- 1 root root 34025516 Aug 18 07:26 cortx-sspl-1.0.0-1_git8907300.el7.noarch.rpm
-    -rw-r--r-- 1 root root 16795340 Aug 18 07:27 cortx-sspl-cli-1.0.0-1_git8907300.el7.noarch.rpm
-    -rw-r--r-- 1 root root  9643028 Aug 18 07:27 cortx-sspl-test-1.0.0-1_git8907300.el7.noarch.rpm
-
-
-    [local_host cortx-monitor]# ls -lrt /root/rpmbuild/RPMS/x86_64/
-    total 284
-    -rw-r--r-- 1 root root  65968 Aug 18 07:23 systemd-python36-1.0.0-1_git8907300.el7.x86_64.rpm
-    -rw-r--r-- 1 root root  60904 Aug 18 07:23 systemd-python36-debuginfo-1.0.0-1_git8907300.el7.x86_64.rpm
-    -rw-r--r-- 1 root root   6552 Aug 18 07:27 cortx-libsspl_sec-1.0.0-1_git8907300.el7.x86_64.rpm
-    -rw-r--r-- 1 root root  28448 Aug 18 07:27 cortx-libsspl_sec-debuginfo-1.0.0-1_git8907300.el7.x86_64.rpm
-    -rw-r--r-- 1 root root   5760 Aug 18 07:27 cortx-libsspl_sec-method_none-1.0.0-1_git8907300.el7.x86_64.rpm
-    -rw-r--r-- 1 root root   9592 Aug 18 07:27 cortx-libsspl_sec-method_pki-1.0.0-1_git8907300.el7.x86_64.rpm
-    -rw-r--r-- 1 root root 101004 Aug 18 07:27 cortx-libsspl_sec-devel-1.0.0-1_git8907300.el7.x86_64.rpm
-    ```
-
 3. Install CORTX-Monitor RPMs
 
-   You'll need to create a repository and copy all the required RPMs to it. Run the commands:
+   SSPL has a `sspl_dev_deploy` script. We need to download and use it to deploy SSPL. Go to the home directory and run following commands.
 
     ```shell
+    $ curl https://raw.githubusercontent.com/Seagate/cortx-monitor/main/low-level/files/opt/seagate/sspl/setup/sspl_dev_deploy -o sspl_dev_deploy
+    $ chmod a+x sspl_dev_deploy
+    ```
+    **sspl_dev_deploy is only meant for dev purpose and to install SSPL independently along with its dependencies.**
+
+4. Deploy SSPL RPMs.
+    ```
+    $ ./sspl_dev_deploy --cleanup
+    $ ./sspl_dev_deploy --prereq -T file:///var/artifacts/0
+    ```
+    :page_with_curl: **Note:** 
+    --cleanup includes removing cortx-py-utils RPM. Any other component RPMS installed on the setup will also get removed while removing cortx-py-utils.
+   
+   Create a template file with the name `~/template_values.1-node.txt`
+    ```
+    # 1-node config variable
+    TMPL_CLUSTER_ID=CC01
+    TMPL_NODE_ID=SN01
+    TMPL_RACK_ID=RC01
+    TMPL_SITE_ID=DC01
+    TMPL_MACHINE_ID=0449364d92b2ba3915fcd8416014cff7
+    TMPL_HOSTNAME=ssc-vm-4778.colo.seagate.com
+    TMPL_NODE_NAME=srvnode-1
+    TMPL_SERVER_NODE_TYPE=VM
+    TMPL_MGMT_INTERFACE=eth0
+    TMPL_MGMT_PUBLIC_FQDN=localhost
+    TMPL_DATA_PRIVATE_FQDN=localhost
+    TMPL_DATA_PRIVATE_INTERFACE=
+    TMPL_DATA_PUBLIC_FQDN=localhost
+    TMPL_DATA_PUBLIC_INTERFACE=
+    TMPL_BMC_IP=
+    TMPL_BMC_USER=
+    TMPL_BMC_SECRET=""
+
+    TMPL_ENCLOSURE_ID=enc_0449364d92b2ba3915fcd8416014cff7
+    TMPL_ENCLOSURE_NAME=enclosure-1
+    TMPL_ENCLOSURE_TYPE=VM
+    TMPL_PRIMARY_CONTROLLER_IP=127.0.0.1
+    TMPL_PRIMARY_CONTROLLER_PORT=28200
+    TMPL_SECONDARY_CONTROLLER_IP=127.0.0.1
+    TMPL_SECONDARY_CONTROLLER_PORT=28200
+    TMPL_CONTROLLER_USER=manage
+    TMPL_CONTROLLER_SECRET=""
+    TMPL_CONTROLLER_TYPE=Gallium
+    ```
+    Make sure to update TMPL_MACHINE_ID, TMPL_HOSTNAME, TMPL_ENCLOSURE_ID, TMPL_BMC_SECRET, TMPL_CONTROLLER_SECRET with actual values.
     
-    $ mkdir MYRPMS
-    $ cp -R /root/rpmbuild/RPMS/x86_64/cortx-libsspl_sec-* /root/rpmbuild/RPMS/noarch/cortx-sspl-* MYRPMS
-    $ find MYRPMS -name \*.rpm -print0 | sudo xargs -0 yum install -y
+    To generate passwords you can use below steps. The encryption keys are generated based on machine id and enclosure id. Feel free to use any sample machine id
+    and enclosure id if actual IDs are not available.
+  
+    ```
+    machine_id="xyz"
+    enclosure_id="enc_xyz"
+    bmc_pass='samplexxxx'
+    encl_pass='samplexxxx'
+
+    bmc_key=$(python3 -c 'from cortx.utils.security.cipher import Cipher; print(Cipher.generate_key('"'$machine_id'"', "server_node"))')
+    encl_key=$(python3 -c 'from cortx.utils.security.cipher import Cipher; print(Cipher.generate_key('"'$enclosure_id'"', "storage_enclosure"))')
+
+    #Encryption
+    encl_encrypt_pass=$(python3 -c 'from cortx.utils.security.cipher import Cipher; print(Cipher.encrypt('$encl_key', '"'$encl_pass'"'.encode()).decode("utf-8"))')
+    bmc_encrypt_pass=$(python3 -c 'from cortx.utils.security.cipher import Cipher; print(Cipher.encrypt('$bmc_key', '"'$bmc_pass'"'.encode()).decode("utf-8"))')
+
+    echo “BMC_SECRET: “$bmc_encrypt_pass
+    echo “ENCL_SECRET:” $encl_encrypt_pass
+    ```
+    Finally run the deployment script
+    ```
+    $ ./sspl_dev_deploy --deploy -T file:///var/artifacts/0 --variable_file /root/template_values.1-node.txt --storage_type RBOD --server_type HW
     ```
 
 4. To start the CORTX-Monitor service, run the commands:
 
     ```shell
-    
-    $ /opt/seagate/cortx/sspl/sspl_init
     $ systemctl start sspl-ll
     $ systemctl status sspl-ll
     ```
@@ -185,8 +216,7 @@ This guide provides a step-by-step walkthrough for getting you CORTX-Monitor Ser
 
   2. Run sanity test using:
 
-      `$ /opt/seagate/cortx/sspl/bin/sspl_test sanity` or,
-      `/opt/seagate/cortx/sspl/sspl_test/run_tests.sh`
+      `$ /opt/seagate/cortx/sspl/bin/sspl_setup test --config yaml:///etc/sspl_global_config_copy.yaml --plan dev_sanity`
 
       **Sample Output:**
     

--- a/cortx-monitorQuickstartGuide.md
+++ b/cortx-monitorQuickstartGuide.md
@@ -261,22 +261,22 @@ This guide provides a step-by-step walkthrough for getting you CORTX-Monitor Ser
     ******************************************************
  ```
 
-## 1.5 Development Cycle.
-There are two option to build again after editing the code
+## 1.5 Development Cycle
+There are two options to build again after editing the code.
 
-1. You can go the checkout location `~/cortx/cortx-monitor` and checkout branch and edit the code and follow the steps.
+1. You can go the checkout location `~/cortx/cortx-monitor`, checkout any branch, edit the code, and follow below steps.
     ```
     $ ./sspl_dev_deploy --cleanup
     $ ./sspl_dev_deploy --prereq -T file:///var/artifacts/0
     $ ./sspl_dev_deploy --deploy -T file:///var/artifacts/0 --variable_file /root/sspl_deploy.conf --storage_type RBOD --server_type HW
     ```
 
-2. To build only SSPL, you can also below steps.
+2. To build only SSPL, you can follow below steps.
     1. Go to sspl repo root directory.
     2. Edit the code.
     3. Build SSPL using `./jenkins/build.sh`
-    4. Copy from `~/rpmbuild/RPMS/` to `~/MYRPMS`
-    5. And then build deploy using belew steps.
+    4. Copy RPMs from `~/rpmbuild/RPMS/` to `~/MYRPMS`
+    5. Build deploy RPMs from local using belew steps.
     ```
     $ ./sspl_dev_deploy --cleanup
     $ ./sspl_dev_deploy --prereq -L /root/MYRPMS

--- a/cortx-monitorQuickstartGuide.md
+++ b/cortx-monitorQuickstartGuide.md
@@ -262,27 +262,27 @@ This guide provides a step-by-step walkthrough for getting you CORTX-Monitor Ser
  ```
 
 ## 1.5 Development Cycle.
-There are two option to build again after editing the code.
+There are two option to build again after editing the code
 
-    1. You can go the checkout location `~/cortx/cortx-monitor` and checkout branch and edit the code and follow the steps.
-        ```
-        $ ./sspl_dev_deploy --cleanup
-        $ ./sspl_dev_deploy --prereq -T file:///var/artifacts/0
-        $ ./sspl_dev_deploy --deploy -T file:///var/artifacts/0 --variable_file /root/sspl_deploy.conf --storage_type RBOD --server_type HW
-        ```
-        
-    2. To build only SSPL, you can also below steps.
-        1. Go to sspl repo root directory.
-        2. Edit the code.
-        3. Build SSPL using `./jenkins/build.sh`
-        4. Copy from `~/rpmbuild/RPMS/` to `~/MYRPMS`
-        5. And then build deploy using belew steps.
-        ```
-        $ ./sspl_dev_deploy --cleanup
-        $ ./sspl_dev_deploy --prereq -L /root/MYRPMS
-        $ ./sspl_dev_deploy --deploy -L /root/MYRPMS --variable_file /root/sspl_deploy.conf --storage_type RBOD --server_type HW
-        ```
-        6. Repeat the same cycle.
+1. You can go the checkout location `~/cortx/cortx-monitor` and checkout branch and edit the code and follow the steps.
+    ```
+    $ ./sspl_dev_deploy --cleanup
+    $ ./sspl_dev_deploy --prereq -T file:///var/artifacts/0
+    $ ./sspl_dev_deploy --deploy -T file:///var/artifacts/0 --variable_file /root/sspl_deploy.conf --storage_type RBOD --server_type HW
+    ```
+
+2. To build only SSPL, you can also below steps.
+    1. Go to sspl repo root directory.
+    2. Edit the code.
+    3. Build SSPL using `./jenkins/build.sh`
+    4. Copy from `~/rpmbuild/RPMS/` to `~/MYRPMS`
+    5. And then build deploy using belew steps.
+    ```
+    $ ./sspl_dev_deploy --cleanup
+    $ ./sspl_dev_deploy --prereq -L /root/MYRPMS
+    $ ./sspl_dev_deploy --deploy -L /root/MYRPMS --variable_file /root/sspl_deploy.conf --storage_type RBOD --server_type HW
+    ```
+    6. Repeat the same cycle.
 
 ## You're All Set & You're Awesome!
 

--- a/cortx-monitorQuickstartGuide.md
+++ b/cortx-monitorQuickstartGuide.md
@@ -261,14 +261,16 @@ This guide provides a step-by-step walkthrough for getting you CORTX-Monitor Ser
     ******************************************************
  ```
 
-## 1.5 Development and Building Again.
+## 1.5 Development Cycle.
 There are two option to build again after editing the code.
+
     1. You can go the checkout location `~/cortx/cortx-monitor` and checkout branch and edit the code and follow the steps.
-    ```
+        ```
         $ ./sspl_dev_deploy --cleanup
         $ ./sspl_dev_deploy --prereq -T file:///var/artifacts/0
         $ ./sspl_dev_deploy --deploy -T file:///var/artifacts/0 --variable_file /root/sspl_deploy.conf --storage_type RBOD --server_type HW
-    ```
+        ```
+        
     2. To build only SSPL, you can also below steps.
         1. Go to sspl repo root directory.
         2. Edit the code.

--- a/cortx-monitorQuickstartGuide.md
+++ b/cortx-monitorQuickstartGuide.md
@@ -191,7 +191,7 @@ This guide provides a step-by-step walkthrough for getting you CORTX-Monitor Ser
     ```
     Finally run the deployment script
     ```
-    $ ./sspl_dev_deploy --deploy -T file:///var/artifacts/0 --variable_file /root/sspl_deploy.conf --storage_type RBOD --server_type HW
+    $ ./sspl_dev_deploy --deploy -T file:///var/artifacts/0 --variable_file ~/sspl_deploy.conf --storage_type RBOD --server_type HW
     ```
 
 4. To start the CORTX-Monitor service, run the commands:
@@ -265,7 +265,7 @@ There are two options to build again after editing the code.
     ```
     $ ./sspl_dev_deploy --cleanup
     $ ./sspl_dev_deploy --prereq -T file:///var/artifacts/0
-    $ ./sspl_dev_deploy --deploy -T file:///var/artifacts/0 --variable_file /root/sspl_deploy.conf --storage_type RBOD --server_type HW
+    $ ./sspl_dev_deploy --deploy -T file:///var/artifacts/0 --variable_file ~/sspl_deploy.conf --storage_type RBOD --server_type HW
     ```
 
 2. To build only SSPL, you can follow below steps.
@@ -276,8 +276,8 @@ There are two options to build again after editing the code.
     5. Build deploy RPMs from local using belew steps.
     ```
     $ ./sspl_dev_deploy --cleanup
-    $ ./sspl_dev_deploy --prereq -L /root/MYRPMS
-    $ ./sspl_dev_deploy --deploy -L /root/MYRPMS --variable_file /root/sspl_deploy.conf --storage_type RBOD --server_type HW
+    $ ./sspl_dev_deploy --prereq -L ~/MYRPMS
+    $ ./sspl_dev_deploy --deploy -L ~/MYRPMS --variable_file ~/sspl_deploy.conf --storage_type RBOD --server_type HW
     ```
     6. Repeat the same cycle.
 

--- a/cortx-monitorQuickstartGuide.md
+++ b/cortx-monitorQuickstartGuide.md
@@ -102,16 +102,13 @@ This guide provides a step-by-step walkthrough for getting you CORTX-Monitor Ser
 
    2. Build cortx-monitor RPMs
         ```
-        docker run --rm -v /var/artifacts:/var/artifacts -v /root/cortx:/cortx-workspace ghcr.io/seagate/cortx-build:centos-7.8.2003 make clean cortx-prvsnr cortx-monitor cortx-prereq release_build
+        docker run --rm -v /var/artifacts:/var/artifacts -v ~/cortx:/cortx-workspace ghcr.io/seagate/cortx-build:centos-7.8.2003 make clean cortx-prvsnr cortx-monitor cortx-prereq release_build
         ```
         
         If you check the location `/var/artifacts/0/`, you will see that Cortx RPMs and 3rd party packages are generated.
 
         ```shell
-        ll /var/artifacts/0/
-        The system output displays as follows:
-
-        [root@ssc-vm-2699 ~]# ll /var/artifacts/0/
+        $ ll /var/artifacts/0/
         total 1608308
         drwxr-xr-x  13 root root       4096 Aug 19 05:16 3rd_party
         drwxr-xr-x   3 root root       4096 Aug 19 05:16 cortx_iso

--- a/low-level/files/opt/seagate/sspl/setup/sspl_dev_deploy
+++ b/low-level/files/opt/seagate/sspl/setup/sspl_dev_deploy
@@ -260,7 +260,7 @@ class SSPLDevDeploy:
 
     def setup_kafka(self):
         """Setup kafka"""
-        cmd = f"yum install -y --nogpgcheck kafka"
+        cmd = "yum install -y --nogpgcheck kafka"
         self._execute_cmd(cmd)
         cmd = "chown -R kafka:kafka /tmp/zookeeper/"
         self._execute_cmd(cmd)

--- a/low-level/files/opt/seagate/sspl/setup/sspl_dev_deploy
+++ b/low-level/files/opt/seagate/sspl/setup/sspl_dev_deploy
@@ -35,6 +35,9 @@ import site
 import importlib
 import tarfile
 import time
+import textwrap
+
+from pathlib import Path
 
 localhost_fqdn = socket.getfqdn()
 SSPL_BASE_DIR = "/opt/seagate/cortx/sspl"
@@ -69,16 +72,10 @@ class SSPLDevDeploy:
             self.build_url = ("http://cortx-storage.colo.seagate.com/releases"
                           "/cortx/github/main/centos-7.9.2009"
                           "/last_successful_prod/")
-            self.cortx_utils_build_url = ("http://cortx-storage.colo.seagate.com/releases/"
-                     "cortx/components/github/main/centos-7.9.2009/"
-                     "dev/cortx-utils/last_successful/")
         elif "CentOS Linux release 7.8" in content:
             self.build_url = ("http://cortx-storage.colo.seagate.com/releases"
                           "/cortx/github/main/centos-7.8.2003"
                           "/last_successful_prod/")
-            self.cortx_utils_build_url = ("http://cortx-storage.colo.seagate.com/releases/"
-                     "cortx/components/github/main/centos-7.8.2003/"
-                     "dev/cortx-utils/last_successful/")
         else:
             raise DeployError(1, "%s is not supported", content)
 
@@ -164,6 +161,15 @@ class SSPLDevDeploy:
         if rc != 0:
             raise DeployError(rc, "%s - %s CMD: %s",
                 out, "Unable to remove cortx-prereq RPMS. Cleanup failed.", cmd)
+        print('Cleaning up local repos...')
+        for p in Path('/etc/yum.repos.d').glob('var_artifacts_*'):
+            p.unlink()
+        for p in Path('/etc/yum.repos.d').glob('cortx-storage.colo.seagate.com_*'):
+            p.unlink()
+        if os.path.exists('/etc/pip.conf'):
+            Path('/etc/pip.conf').unlink()
+        self._execute_cmd('yum clean all')
+        shutil.rmtree('/var/cache/yum/')
 
     def setup_yum_repos(self):
         """Setup common, 3rd_party and build specific repos."""
@@ -171,34 +177,20 @@ class SSPLDevDeploy:
             raise DeployError(1, "Target build or RPMS path is not given.")
         pkg_name = "cortx-prereq"
         print("INFO: INSTALLING %s..." % pkg_name)
-        prereq_url = ("http://cortx-storage.colo.seagate.com/releases/cortx/"
-            "third-party-deps/rpm/install-cortx-prereq.sh")
-        with urllib.request.urlopen(prereq_url) as response, open(
-                "install-cortx-prereq.sh", 'wb') as out_file:
-            shutil.copyfileobj(response, out_file)
-        os.chmod("install-cortx-prereq.sh", 0o775)
-        cmd = "sh install-cortx-prereq.sh"
 
-        if self.target_build:
-            cmd = cmd + " -b " + self.target_build
-            out, rc = self._execute_cmd(cmd)
-            if rc != 0:
-                raise DeployError(rc, "%s - %s CMD: %s",
-                    out, "Failed to install %s." % (pkg_name), cmd)
-            # Add repos to yum.repos.d
-            cmd1 = "yum-config-manager --add-repo %s/cortx_iso/" % self.target_build
-            cmd2 = "yum-config-manager --add-repo %s/3rd_party/" % self.target_build
-            for repo_cmd in [cmd1, cmd2]:
-                out, rc = self._execute_cmd(repo_cmd)
-                if rc != 0:
-                    raise DeployError(rc, "%s - %s CMD: %s",
-                        out, "Setup repo failed", repo_cmd)
-        else:
-            out, rc = self._execute_cmd(cmd)
-            if rc != 0:
-                raise DeployError(rc, "%s - %s CMD: %s",
-                    out, "Failed to install %s." % (pkg_name), cmd)
-            repo_cmd = "yum-config-manager --add-repo %s/3rd_party/" % self.build_url
+        repo_url = self.target_build if self.target_build else self.build_url
+
+        cmd1 = "yum-config-manager --add-repo %s/cortx_iso/" % repo_url
+        cmd2 = "yum-config-manager --add-repo %s/3rd_party/" % repo_url
+        with open('/etc/pip.conf', 'w') as pw:
+            cont = textwrap.dedent("""
+                [global]
+                timeout: 60
+                index-url: {}/python_deps/
+                trusted-host: localhost\n""").format(self.target_build)
+            pw.write(cont)
+        install_prereq_command = "yum install --nogpgcheck -y python3 cortx-prereq"
+        for repo_cmd in [cmd1, cmd2, install_prereq_command]:
             out, rc = self._execute_cmd(repo_cmd)
             if rc != 0:
                 raise DeployError(rc, "%s - %s CMD: %s",
@@ -208,13 +200,7 @@ class SSPLDevDeploy:
         """Install dependencies."""
         pkg_name = "cortx-py-utils"
         print("INFO: INSTALLING cortx-py-utils...")
-        print("Downloading pyutils from %s" % self.build_url)
-        pkg = [re.findall("<a .*>(.*?)</a>", str(line))[0]
-               for line in urllib.request.urlopen(self.cortx_utils_build_url).readlines()
-               if pkg_name in str(line)]
-        if not pkg:
-            print(f"ERROR: Unable to download {pkg_name}.")
-        cmd = "yum install -y %s%s" % (self.cortx_utils_build_url, pkg[0])
+        cmd = "yum install -y --nogpgcheck cortx-py-utils"
         out, rc = self._execute_cmd(cmd)
         if rc != 0:
             raise DeployError(rc, "%s - %s CMD: %s",
@@ -273,13 +259,7 @@ class SSPLDevDeploy:
 
     def setup_kafka(self):
         """Setup kafka"""
-        build_url = f"{self.build_url}/3rd_party/commons/kafka/"
-
-        pkg = [re.findall("<a .*>(.*?)</a>", str(line))[0] for line in 
-               urllib.request.urlopen(build_url).readlines()
-               if re.search(r"kafka.*\.rpm", str(line))][0]
-
-        cmd = f"yum install -y {build_url}{pkg}"
+        cmd = f"yum install -y --nogpgcheck kafka"
         self._execute_cmd(cmd)
         cmd = "chown -R kafka:kafka /tmp/zookeeper/"
         self._execute_cmd(cmd)

--- a/low-level/files/opt/seagate/sspl/setup/sspl_dev_deploy
+++ b/low-level/files/opt/seagate/sspl/setup/sspl_dev_deploy
@@ -190,8 +190,8 @@ class SSPLDevDeploy:
                 trusted-host: localhost\n""").format(self.target_build)
             pw.write(cont)
         python_install_command = "yum install -y python3"
-        kafka_install_command = "yum install --nogpgcheck -y cortx-prereq"
-        for repo_cmd in [cmd1, cmd2, python_install_command, kafka_install_command]:
+        prereq_install_command = "yum install --nogpgcheck -y cortx-prereq"
+        for repo_cmd in [cmd1, cmd2, python_install_command, prereq_install_command]:
             out, rc = self._execute_cmd(repo_cmd)
             if rc != 0:
                 raise DeployError(rc, "%s - %s CMD: %s",

--- a/low-level/files/opt/seagate/sspl/setup/sspl_dev_deploy
+++ b/low-level/files/opt/seagate/sspl/setup/sspl_dev_deploy
@@ -164,7 +164,7 @@ class SSPLDevDeploy:
         print('Cleaning up local repos...')
         for p in Path('/etc/yum.repos.d').glob('var_artifacts_*'):
             p.unlink()
-        for p in Path('/etc/yum.repos.d').glob('cortx-storage.colo.seagate.com_*'):
+        for p in Path('/etc/yum.repos.d').glob('cortx-*'):
             p.unlink()
         if os.path.exists('/etc/pip.conf'):
             Path('/etc/pip.conf').unlink()

--- a/low-level/files/opt/seagate/sspl/setup/sspl_dev_deploy
+++ b/low-level/files/opt/seagate/sspl/setup/sspl_dev_deploy
@@ -189,8 +189,9 @@ class SSPLDevDeploy:
                 index-url: {}/python_deps/
                 trusted-host: localhost\n""").format(self.target_build)
             pw.write(cont)
-        install_prereq_command = "yum install --nogpgcheck -y python3 cortx-prereq"
-        for repo_cmd in [cmd1, cmd2, install_prereq_command]:
+        python_install_command = "yum install -y python3"
+        kafka_install_command = "yum install --nogpgcheck -y cortx-prereq"
+        for repo_cmd in [cmd1, cmd2, python_install_command, kafka_install_command]:
             out, rc = self._execute_cmd(repo_cmd)
             if rc != 0:
                 raise DeployError(rc, "%s - %s CMD: %s",


### PR DESCRIPTION
Signed-off-by: Thavanathan Thangaraj <thavanathan.thangaraj@seagate.com>

<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:
SSPL should be able to deploy outside Seagate network

## Solution Design:
We set Cortx repo locally and dev deploy script has been updated to use local build repo.

## Coding:

* [ ] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [ ] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [ ] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [ ] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [ ] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [ ] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [ ] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->


-----
[View rendered cortx-monitorQuickstartGuide.md](https://github.com/thavanathan/cortx-monitor/blob/qsg/cortx-monitorQuickstartGuide.md)