### PR TITLE
EOS-23220: Collect CPU information from the correct location in the s…

### DIFF
--- a/low-level/files/opt/seagate/sspl/conf/sspl.conf.LR2.yaml
+++ b/low-level/files/opt/seagate/sspl/conf/sspl.conf.LR2.yaml
@@ -186,7 +186,7 @@ MEMFAULTSENSOR:
 CPUFAULTSENSOR:
    monitor: true
    threaded: true
-   probe: sysfs
+   probe: dmidecode
 
 STORAGE_ENCLOSURE:
    mgmt_interface: cliapi

--- a/low-level/framework/sspl_reinit
+++ b/low-level/framework/sspl_reinit
@@ -51,7 +51,7 @@ usermod -a -G disk sspl-ll
 usermod -a -G disk sspl-ll
 
 # Update the sudoers file with the sspl-ll user and available commands
-SUDO_LINE="sspl-ll	ALL = NOPASSWD: /usr/sbin/smartctl, /usr/sbin/mdadm, /usr/bin/mount, /usr/bin/umount, /usr/sbin/swapon, /usr/sbin/swapoff, /usr/sbin/hdparm, /usr/bin/systemctl, /usr/sbin/wbcli, /usr/bin/ipmitool, /usr/bin/systemd-detect-virt, /bin/tee, /usr/bin/facter"
+SUDO_LINE="sspl-ll	ALL = NOPASSWD: /usr/sbin/smartctl, /usr/sbin/mdadm, /usr/bin/mount, /usr/bin/umount, /usr/sbin/swapon, /usr/sbin/swapoff, /usr/sbin/hdparm, /usr/bin/systemctl, /usr/sbin/wbcli, /usr/bin/ipmitool, /usr/bin/systemd-detect-virt, /bin/tee, /usr/bin/facter, /sbin/dmidecode"
 [ "$PRODUCT_NAME" == "LDR_R1" ] && SUDO_LINE="${SUDO_LINE}, /usr/bin/provisioner, /bin/salt-call"
 
 echo "$SUDO_LINE" | tee /etc/sudoers.d/sspl > /dev/null

--- a/low-level/framework/utils/dmidecode_interface.py
+++ b/low-level/framework/utils/dmidecode_interface.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2019-2020 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>. For any questions
+# about this software or licensing, please email opensource@seagate.com or
+# cortx-questions@seagate.com.
+
+"""
+Module which provides system information using 'dmidecode' command
+"""
+
+import re
+
+from pathlib import Path
+from framework.utils.utility import Utility
+from framework.utils.service_logging import logger
+from cortx.utils.process import SimpleProcess
+
+class Dmidecode(Utility):
+    """
+    Interface class to retrieve system's hardware related information
+    using 'dmidecode' command.
+    """
+    DMIDECODE = "sudo /sbin/dmidecode"
+
+    def __init__(self):
+        """init method"""
+        super(Dmidecode, self).__init__()
+
+    def get_cpu_info(self):
+        """Returns online cpus list"""
+        try:
+            cmd = self.DMIDECODE + " -t 4"
+            response, err, _ = SimpleProcess(cmd).run()
+            if err:
+                logger.error("Failed to get list of Online CPUs."
+                             f"ERROR:{err}")
+                return
+            matches = re.findall("Socket Designation:.*|"
+                                 "Status:.*", response.decode())
+    
+            cpu_map = {}
+            cpu = cpu_status = None
+            while matches:
+                item = matches.pop(0)
+                if "Designation:" in item:
+                    cpu = item.strip().split(": ")[1]
+                if "Status:" in item:
+                    cpu_status = item.strip().split(": ")[1]
+                if cpu and cpu_status:
+                    cpu_map[cpu] = cpu_status
+            logger.debug(f"Mapping of CPU and status:{cpu_map}")
+            online_cpus = []
+            for cpu, status in cpu_map.items():
+                if "Enabled" in status:
+                    online_cpus.append(cpu)
+            logger.info(f"Online CPU list:{online_cpus}")
+            return online_cpus
+        except Exception as e:
+            logger.error(f"Failed to get online CPUs info. ERROR:{e}")
+

--- a/low-level/framework/utils/sysfs_interface.py
+++ b/low-level/framework/utils/sysfs_interface.py
@@ -89,40 +89,6 @@ class SysFS(Utility):
                     phy_dir[phy_name] = link_rate
         return phy_dir
 
-    def convert_cpu_info_list(self, cpu_info):
-        """Converts cpu info as read from file to a list of cpu indexes
-        eg. '0-2,4,6-8' => [0,1,2,4,6,7,8]
-        """
-        # Split the string with comma
-        cpu_info = cpu_info.split(',')
-        cpu_list = []
-        for item in cpu_info:
-            # Split item with a hyphen if it is a range of indexes
-            item = item.split('-')
-            if len(item) == 2:
-                # Item is a range
-                num1 = int(item[0])
-                num2 = int(item[1])
-                # Append all indexes in that range
-                for i in range(num1,num2+1):
-                    cpu_list.append(i)
-            elif len(item) == 1:
-                # Item is a single index
-                cpu_list.append(int(item[0]))
-        return cpu_list
-
-    def get_cpu_info(self):
-        """Returns the cpus online after reading /sys/devices/system/cpu/online
-        """
-        cpu_info_path = Path(self.cpu_online_fp)
-        # Read the text from /cpu/online file
-        cpu_info = cpu_info_path.read_text()
-        # Drop the \n character from the end of string
-        cpu_info = cpu_info.rstrip('\n')
-        # Convert the string to list of indexes
-        cpu_list = self.convert_cpu_info_list(cpu_info)
-        return cpu_list
-
     def fetch_nw_cable_status(self, nw_interface_path, interface):
         '''
            Gets the status of nw carrier cable from the path:

--- a/low-level/framework/utils/tool_factory.py
+++ b/low-level/framework/utils/tool_factory.py
@@ -19,6 +19,7 @@ Factory module which returns instance of specific tool/utility class.
 
 from framework.utils.sysfs_interface import *
 from framework.utils.procfs_interface import *
+from framework.utils.dmidecode_interface import *
 
 class ToolFactory(object):
     """"Returns instance of a specific Tool class from the factory"""

--- a/low-level/sensors/impl/generic/cpu_fault_sensor.py
+++ b/low-level/sensors/impl/generic/cpu_fault_sensor.py
@@ -52,8 +52,6 @@ class CPUFaultSensor(SensorThread, InternalMsgQ):
     SYSTEM_INFORMATION_KEY = "SYSTEM_INFORMATION"
     CACHE_DIR_NAME  = "server"
 
-    RESOURCE_ID = "CPU-"
-
     PROBE = "probe"
 
     # Dependency list
@@ -92,7 +90,7 @@ class CPUFaultSensor(SensorThread, InternalMsgQ):
 
         # get the cpu fault implementor from configuration
         cpu_fault_utility = Conf.get(SSPL_CONF, f"{self.name().capitalize()}>{self.PROBE}",
-                                    'sysfs')
+                                    'dmidecode')
 
         # Creating the instance of ToolFactory class
         self.tool_factory = ToolFactory()
@@ -201,7 +199,7 @@ class CPUFaultSensor(SensorThread, InternalMsgQ):
             # Iterate through the set
             for cpu in cpu_list:
                 item = {}
-                item['resource_id'] = self.RESOURCE_ID + str(cpu)
+                item['resource_id'] = str(cpu)
                 # Keep default state online
                 item['state'] = "online"
                 if cpu in self.alerts_for.keys():
@@ -224,7 +222,7 @@ class CPUFaultSensor(SensorThread, InternalMsgQ):
         # Populate specific info
         self.fill_specific_info()
         alert_specific_info = self.specific_info
-        res_id = self.RESOURCE_ID + str(cpu)
+        res_id = str(cpu)
 
         for item in alert_specific_info:
             if item['resource_id'] == res_id:
@@ -235,7 +233,7 @@ class CPUFaultSensor(SensorThread, InternalMsgQ):
 
         info = {
                 "resource_type": self.RESOURCE_TYPE,
-                "resource_id": self.RESOURCE_ID + str(cpu),
+                "resource_id": str(cpu),
                 "event_time": epoch_time,
                 "description": description
                 }


### PR DESCRIPTION
…ensor

<!-- Please note that your PR will not be accepted if all of below questions are not answered. -->

## Problem Statement:

Currently, we are collecting CPU information from /sys/devices/system/cpu/online and  /sys/devices/system/cpu/offline location but actually, it is thread count which is related to CPU and it is not actual CPUs.

## Solution Design:

Design changes to read the physical processor status instead of CPU threads

## Coding:

* [ ] Did you follow coding standard and verified it with flake8? 
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/219612361/Coding+Standard -->
* [x] Did your address all Codacy issues?

<!-- Explain code changes here. -->

## Testing:

* [ ] Unittest updated and all unittests are passing?
<!-- Describe newly added or updated unittests here  -->

* [ ] Sanity/Self tests are updated (if applicable)?
<!-- Describe newly added or updated sanity tests here if applicable-->

* [x] Manual testing done covering happy path and non-happy path?

## Integration:

* [ ] If there is any interface change, did you communicate it to other components?
* [ ] If there is any interface change, other componenent gate gatekeepers are ready to accept the change?
* [ ] Did you complete deployment test if applicable?
<!-- If not applicable, explain here why? -->

## PR checklist:
* [x] Did you add Jira number to the PR?
<!-- Format eg: EOS-12345: <commit msg>  -->

* [x] DCO and cla-signed?
<!-- For instructions, refer https://seagate-systems.atlassian.net/wiki/spaces/sspl/pages/349176078/Pull+Request+Checks -->
